### PR TITLE
Fix community repo icon duplication and tab hover artifacts

### DIFF
--- a/V1.9/theme-v1.11.0.css
+++ b/V1.9/theme-v1.11.0.css
@@ -22745,11 +22745,11 @@ body:is(.ssopt-tabs-modern-borderless) {
   TAB IMPLEMENTATION FOR FIREFOX-STYLE
 ================================================================================
 */
-.workspace-fake-target-overlay:not(.is-in-sidebar) .workspace-tab-header.is-active::before,
-.workspace-fake-target-overlay:not(.is-in-sidebar) .workspace-tab-header.is-active::after,
-.workspace-split.mod-root .workspace-tab-header.is-active::before,
-.workspace-split.mod-root .workspace-tab-header.is-active::after {
-  box-shadow: none;
+body:not(.ssopt-tabs-index-old) .workspace-fake-target-overlay:not(.is-in-sidebar) .workspace-tab-header.is-active::before,
+body:not(.ssopt-tabs-index-old) .workspace-fake-target-overlay:not(.is-in-sidebar) .workspace-tab-header.is-active::after,
+body:not(.ssopt-tabs-index-old) .workspace-split.mod-root .workspace-tab-header.is-active::before,
+body:not(.ssopt-tabs-index-old) .workspace-split.mod-root .workspace-tab-header.is-active::after {
+  box-shadow: none !important;
 }
 
 body:not(.ssopt-no-pin-tab-front) .workspace-tab-header-container-inner .workspace-tab-header:has(.mod-pinned) {
@@ -32056,7 +32056,7 @@ body:not(.is-phone, .ssopt-revert-mod-community) .modal.mod-community-theme .mod
   background-color: var(--background-secondary);
   border-radius: var(--radius-s);
   transition: background-color 0.2s ease-in-out;
-  content: "";
+  content: none;
   flex-shrink: 0;
   margin-left: auto;
 
@@ -32474,7 +32474,7 @@ body:not(.is-phone, .ssopt-revert-mod-community) .modal.mod-community-plugin .mo
   background-color: var(--background-secondary);
   border-radius: var(--radius-s);
   transition: background-color 0.2s ease-in-out;
-  content: " ";
+  content: none;
   flex-shrink: 0;
   margin-left: auto;
 }
@@ -32516,6 +32516,7 @@ body:not(.is-phone, .ssopt-revert-mod-community) .modal.mod-community-plugin .mo
   transition: opacity 0.2s ease-in-out;
 }
 
+.modal.mod-community-plugin .community-modal-info .community-modal-info-repo:has(> a[aria-label="View the latest update"]),
 .modal.mod-community-plugin .community-modal-info .community-modal-info-repo:last-of-type {
   display: none;
 }

--- a/theme.css
+++ b/theme.css
@@ -22745,11 +22745,11 @@ body:is(.ssopt-tabs-modern-borderless) {
   TAB IMPLEMENTATION FOR FIREFOX-STYLE
 ================================================================================
 */
-.workspace-fake-target-overlay:not(.is-in-sidebar) .workspace-tab-header.is-active::before,
-.workspace-fake-target-overlay:not(.is-in-sidebar) .workspace-tab-header.is-active::after,
-.workspace-split.mod-root .workspace-tab-header.is-active::before,
-.workspace-split.mod-root .workspace-tab-header.is-active::after {
-  box-shadow: none;
+body:not(.ssopt-tabs-index-old) .workspace-fake-target-overlay:not(.is-in-sidebar) .workspace-tab-header.is-active::before,
+body:not(.ssopt-tabs-index-old) .workspace-fake-target-overlay:not(.is-in-sidebar) .workspace-tab-header.is-active::after,
+body:not(.ssopt-tabs-index-old) .workspace-split.mod-root .workspace-tab-header.is-active::before,
+body:not(.ssopt-tabs-index-old) .workspace-split.mod-root .workspace-tab-header.is-active::after {
+  box-shadow: none !important;
 }
 
 body:not(.ssopt-no-pin-tab-front) .workspace-tab-header-container-inner .workspace-tab-header:has(.mod-pinned) {
@@ -32056,7 +32056,7 @@ body:not(.is-phone, .ssopt-revert-mod-community) .modal.mod-community-theme .mod
   background-color: var(--background-secondary);
   border-radius: var(--radius-s);
   transition: background-color 0.2s ease-in-out;
-  content: "";
+  content: none;
   flex-shrink: 0;
   margin-left: auto;
 
@@ -32474,7 +32474,7 @@ body:not(.is-phone, .ssopt-revert-mod-community) .modal.mod-community-plugin .mo
   background-color: var(--background-secondary);
   border-radius: var(--radius-s);
   transition: background-color 0.2s ease-in-out;
-  content: " ";
+  content: none;
   flex-shrink: 0;
   margin-left: auto;
 }
@@ -32516,6 +32516,7 @@ body:not(.is-phone, .ssopt-revert-mod-community) .modal.mod-community-plugin .mo
   transition: opacity 0.2s ease-in-out;
 }
 
+.modal.mod-community-plugin .community-modal-info .community-modal-info-repo:has(> a[aria-label="View the latest update"]),
 .modal.mod-community-plugin .community-modal-info .community-modal-info-repo:last-of-type {
   display: none;
 }


### PR DESCRIPTION
## Summary

This PR fixes two small visual regressions I observed in Willemstad 1.11.1 on Obsidian 1.12.7:

- The Community Plugin details pane can show the repository icon twice because Obsidian now uses `.community-modal-info-repo` for both the `Repository` row and the `Last update` row.
- In light mode, the active tab can show two pale side blocks on hover because Obsidian's active-tab pseudo-element shadows can override the existing reset.

It also removes the extra pseudo-element background behind the repository icon, which could appear as a separate grey square in light mode.

## Screenshots

### 1. Community Plugin details: duplicate repository icon

Before: both the real repository link and the latest-update link are styled as repository icons.

<img src="https://raw.githubusercontent.com/oldwinter/willemstad-x/8ed964825c266613d79876322e4b69058c2ef8de/pr-assets/pr-77/before-community-duplicate-icon.png" alt="Before: duplicate repository icons in Community Plugin details" width="760">

After: only the real repository icon remains.

<img src="https://raw.githubusercontent.com/oldwinter/willemstad-x/8ed964825c266613d79876322e4b69058c2ef8de/pr-assets/pr-77/after-community-single-icon-no-square.png" alt="After: one repository icon remains in Community Plugin details" width="760">

### 2. Community Plugin details: grey square behind the repository icon

Before: the repository-link `::before` layer can render as a standalone grey square.

<img src="https://raw.githubusercontent.com/oldwinter/willemstad-x/8ed964825c266613d79876322e4b69058c2ef8de/pr-assets/pr-77/before-community-gray-square.png" alt="Before: grey square behind Community Plugin repository icon" width="760">

After: the `::before` layer is disabled, while the actual masked repository icon on `::after` is preserved.

<img src="https://raw.githubusercontent.com/oldwinter/willemstad-x/8ed964825c266613d79876322e4b69058c2ef8de/pr-assets/pr-77/after-community-single-icon-no-square.png" alt="After: repository icon without grey square" width="760">

### 3. Light mode active tab hover artifacts

Before: hovering the active tab can show two pale curved blocks at the tab edges.

<img src="https://raw.githubusercontent.com/oldwinter/willemstad-x/8ed964825c266613d79876322e4b69058c2ef8de/pr-assets/pr-77/before-tab-hover-artifacts.png" alt="Before: light mode active tab hover shows pale side blocks" width="760">

After: the active tab keeps the Willemstad shape without the extra pale side blocks.

<img src="https://raw.githubusercontent.com/oldwinter/willemstad-x/8ed964825c266613d79876322e4b69058c2ef8de/pr-assets/pr-77/after-tab-hover-clean.png" alt="After: light mode active tab hover without pale side blocks" width="760">

## Root Cause

### Community Plugin modal

Current Obsidian builds can render both `Repository` and `Last update` rows with the same `.community-modal-info-repo` class. Willemstad styles every matching row as a repository icon, so the latest-update link can become a second repository icon.

The repository icon is also split across two pseudo-elements:

- `a::before` draws a background layer.
- `a::after` draws the masked repository icon.

When the background layer is visible by itself, it appears as the small grey square shown above.

### Active tab hover

The theme already resets active tab pseudo-element shadows, but the selector can lose to current Obsidian app styles. In light mode, the default active-tab curve shadows can leak through as pale blocks around the active tab.

## Fix

- Hide only the latest-update row in the Community Plugin modal:
  ```css
  .modal.mod-community-plugin .community-modal-info .community-modal-info-repo:has(> a[aria-label="View the latest update"])
  ```
- Keep the existing `:last-of-type` fallback for compatibility.
- Disable the repository-link background pseudo-element with `content: none`, while preserving the actual repository icon on `a::after`.
- Strengthen the active-tab pseudo-element reset with:
  ```css
  body:not(.ssopt-tabs-index-old) ...
  box-shadow: none !important;
  ```
- The `body:not(.ssopt-tabs-index-old)` guard is intentional so the older Classic Index tab style can keep its curved active-tab treatment.

## Notes

This repo appears to publish compiled CSS for current 1.11.x releases, so this PR updates both:

- `theme.css`
- `V1.9/theme-v1.11.0.css`

No SCSS source was changed because the README notes that the uncompiled SASS/SCSS source is no longer published from version 1.1 onward.

## Validation

- `git diff --check`
- Custom selector assertions over `theme.css` and `V1.9/theme-v1.11.0.css`
- Manual check in Obsidian 1.12.7 with Willemstad 1.11.1:
  - the plugin modal shows one repository icon,
  - the grey square is gone,
  - the latest-update row is hidden in the details pane,
  - active tab pseudo-elements compute to `box-shadow: none`.
