### PR TITLE
Fix --canvas-color for Obsidian 1.13+

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -22073,29 +22073,29 @@ supported. RGB values in Obs is therefore useless (and should be deprecated)
 
 /* ---------- canvas ---------- */
 .canvas-node-placeholder::after {
-  background-color: oklch(from rgb(var(--canvas-color)) l c h/10%);
+  background-color: oklch(from var(--canvas-color) l c h/10%);
 }
 
 .canvas-node.is-themed .canvas-node-container {
-  border-color: oklch(from rgb(var(--canvas-color)) l c h/70%);
-  box-shadow: inset 0 0 0 1px oklch(from rgb(var(--canvas-color)) l c h/70%), var(--shadow-stationary);
+  border-color: oklch(from var(--canvas-color) l c h/70%);
+  box-shadow: inset 0 0 0 1px oklch(from var(--canvas-color) l c h/70%), var(--shadow-stationary);
 }
 
 .canvas-node-group .canvas-node-content {
-  background-color: oklch(from rgb(var(--canvas-color)) l c h/7%);
+  background-color: oklch(from var(--canvas-color) l c h/7%);
 }
 
 .canvas-group-label {
-  background-color: oklch(from rgb(var(--canvas-color)) l c h/10%);
+  background-color: oklch(from var(--canvas-color) l c h/10%);
 }
 
 .canvas-node.is-themed .canvas-node-content {
-  background-color: oklch(from rgb(var(--canvas-color)) l c h/7%);
+  background-color: oklch(from var(--canvas-color) l c h/7%);
 }
 
 .canvas-edges g.is-focused path.canvas-interaction-path,
 .canvas:not(.is-connecting) .canvas-edges g:hover path.canvas-interaction-path {
-  stroke: oklch(from rgb(var(--canvas-color)) l c h/10%);
+  stroke: oklch(from var(--canvas-color) l c h/10%);
 }
 
 /* ---------- misc ---------- */
@@ -22247,13 +22247,13 @@ body {
 
 .theme-light {
   /*
-    --color-red-rgb: 233, 49, 71;
-    --color-orange-rgb: 236, 117, 0;
-    --color-yellow-rgb: 224, 172, 0;
-    --color-green-rgb: 8, 185, 78;
-    --color-cyan-rgb: 0, 191, 188;
+    --color-red-rgb: rgb(233, 49, 71);
+    --color-orange-rgb: rgb(236, 117, 0);
+    --color-yellow-rgb: rgb(224, 172, 0);
+    --color-green-rgb: rgb(8, 185, 78);
+    --color-cyan-rgb: rgb(0, 191, 188);
     --color-blue-rgb: 8, 109, 221;
-    --color-purple-rgb: 120, 82, 238;
+    --color-purple-rgb: rgb(120, 82, 238);
     --color-pink-rgb: 213, 57, 132;
   */
 }


### PR DESCRIPTION
Hello! I'm [saberzero1](https://github.com/saberzero1), a [community reviewer](https://obsidian.md/help/credits#Community+review) for Obsidian plugins and themes. We're sending this PR out to you proactively to help you prepare for a recent Obsidian update.

## Summary

Obsidian 1.13 changed how `--canvas-color` (and `--canvas-color-1` through `--canvas-color-6`) works. It now provides a valid CSS color value (e.g. `#e93147`) instead of a bare RGB triplet (`233, 49, 71`).

This breaks two patterns:

**1. Bare RGB triplets in declarations:**
```css
/* Before (broken on 1.13+) */
--canvas-color-1: 255, 0, 128;
/* After */
--canvas-color-1: rgb(255, 0, 128);
```

**2. Wrapping `var(--canvas-color)` in `rgb()`/`rgba()`:**
```css
/* Before (produces invalid rgb(rgb(...)) on 1.13+) */
background: rgba(var(--canvas-color), 0.1);
/* After */
background: color-mix(in srgb, var(--canvas-color) 10%, transparent);
```

## Changes

- Wrapped bare RGB triplets in `--canvas-color` / `--canvas-color-N` declarations with `rgb()`
- Replaced `rgb(var(--canvas-color))` with `var(--canvas-color)`
- Replaced `rgba(var(--canvas-color), <alpha>)` with `color-mix(in srgb, var(--canvas-color) <percent>, transparent)`
- Updated `minAppVersion` in `manifest.json` to `1.13.0` (if it was lower)

## Context

See the [Obsidian 1.13 changelog](https://obsidian.md/changelog/) for details on this breaking change.
