### PR TITLE
Use complete callout colours and bound active-line highlight geometry

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -6631,12 +6631,12 @@ span.cm-strong.cm-em.cm-highlight {
 
 /* opinionated stuff */
 body:not(.callout-standard) .callout {
-  border-left: 0rem solid rgb(var(--callout-color));
+  border-left: 0rem solid var(--callout-color);
   border-radius: calc(var(--shape-roundish) * 1.25);
   transition: var(--quick-transition);
 }
 body:not(.callout-standard) .callout:hover {
-  border-left: 0.3rem solid rgb(var(--callout-color));
+  border-left: 0.3rem solid var(--callout-color);
   transition: var(--quick-transition);
 }
 body:not(.callout-standard) .callout-title {
@@ -6816,16 +6816,16 @@ body:not(.callout-standard) {
   /* test stuff */
 }
 body:not(.callout-standard) .callout .callout-title {
-  background-color: rgba(var(--callout-color), 0.125);
+  background-color: color-mix(in srgb, var(--callout-color) 12.5%, transparent);
 }
 body:not(.callout-standard) .callout .callout-title-inner {
   /* opacity: 0.9; */
-  color: rgb(var(--callout-color));
+  color: var(--callout-color);
   -webkit-font-smoothing: antialiased;
 }
 body:not(.callout-standard) .callout:is([data-callout=note],
 [data-callout=aside]) {
-  --callout-color: 0, 191, 111;
+  --callout-color: rgb(0, 191, 111);
   /*
   & .callout-title-inner {
 
@@ -6844,16 +6844,16 @@ body:not(.callout-standard) .callout:is([data-callout=note],
 body:not(.callout-standard) .callout:is([data-callout=abstract],
 [data-callout=summary],
 [data-callout=tldr]) {
-  --callout-color: 91, 197, 219;
+  --callout-color: rgb(91, 197, 219);
   --callout-icon: loader;
 }
 body:not(.callout-standard) .callout:is([data-callout=info],
 [data-callout=todo]) {
-  --callout-color: 0, 170, 199;
+  --callout-color: rgb(0, 170, 199);
 }
 body:not(.callout-standard) .callout:is([data-callout=tip],
 [data-callout=hint]) {
-  --callout-color: 34, 148, 1;
+  --callout-color: rgb(34, 148, 1);
   --callout-icon: asterisk;
 }
 body:not(.callout-standard).theme-dark .callout:is([data-callout=tip], [data-callout=hint]) :is(.callout-title-inner, .callout-icon svg) {
@@ -6862,7 +6862,7 @@ body:not(.callout-standard).theme-dark .callout:is([data-callout=tip], [data-cal
 
 body:not(.callout-standard) .callout:is([data-callout=check],
 [data-callout=done]) {
-  --callout-color: 0, 158, 76;
+  --callout-color: rgb(0, 158, 76);
 }
 body:not(.callout-standard).theme-dark .callout:is([data-callout=check], [data-callout=done]) :is(.callout-title-inner, .callout-icon svg) {
   color: #00cc63;
@@ -6871,18 +6871,18 @@ body:not(.callout-standard).theme-dark .callout:is([data-callout=check], [data-c
 body:not(.callout-standard) .callout:is([data-callout=question],
 [data-callout=help],
 [data-callout=faq]) {
-  --callout-color: 160, 199, 92;
+  --callout-color: rgb(160, 199, 92);
 }
 body:not(.callout-standard) .callout:is([data-callout=warning],
 [data-callout=caution],
 [data-callout=attention]) {
-  /* --callout-color: 237, 183, 50; */
-  --callout-color: 255, 182, 26;
+  /* --callout-color: rgb(237, 183, 50); */
+  --callout-color: rgb(255, 182, 26);
 }
 body:not(.callout-standard) .callout:is([data-callout=failure],
 [data-callout=fail],
 [data-callout=missing]) {
-  --callout-color: 161, 40, 100;
+  --callout-color: rgb(161, 40, 100);
 }
 body:not(.callout-standard).theme-dark .callout:is([data-callout=failure], [data-callout=fail], [data-callout=missing]) :is(.callout-title-inner, .callout-icon svg) {
   color: #db70a6;
@@ -6890,21 +6890,21 @@ body:not(.callout-standard).theme-dark .callout:is([data-callout=failure], [data
 
 body:not(.callout-standard) .callout:is([data-callout=danger],
 [data-callout=error]) {
-  --callout-color: 241, 0, 34;
+  --callout-color: rgb(241, 0, 34);
 }
 body:not(.callout-standard).theme-dark .callout:is([data-callout=danger], [data-callout=error]) :is(.callout-title-inner, .callout-icon svg) {
   color: #ff334e;
 }
 
 body:not(.callout-standard) .callout:is([data-callout=bug]) {
-  --callout-color: 164, 103, 80;
+  --callout-color: rgb(164, 103, 80);
 }
 body:not(.callout-standard).theme-dark .callout:is([data-callout=bug]) :is(.callout-title-inner, .callout-icon svg) {
   color: #bc8976;
 }
 
 body:not(.callout-standard) .callout:is([data-callout=example]) {
-  --callout-color: 125, 84, 178;
+  --callout-color: rgb(125, 84, 178);
 }
 body:not(.callout-standard).theme-dark .callout:is([data-callout=example]) :is(.callout-title-inner, .callout-icon svg) {
   color: #a184c8;
@@ -6912,16 +6912,16 @@ body:not(.callout-standard).theme-dark .callout:is([data-callout=example]) :is(.
 
 body:not(.callout-standard) .callout:is([data-callout=quote],
 [data-callout=cite]) {
-  --callout-color: 161, 169, 173;
+  --callout-color: rgb(161, 169, 173);
 }
 body:not(.callout-standard) .callout:is([data-callout^=attachment],
 [data-callout^=file]) {
-  --callout-color: 197, 101, 199;
+  --callout-color: rgb(197, 101, 199);
   --callout-icon: paperclip;
 }
 body:not(.callout-standard) .callout:is([data-callout=link],
 [data-callout=url]) {
-  --callout-color: 127, 127, 127;
+  --callout-color: rgb(127, 127, 127);
   --callout-icon: link;
 }
 body:not(.callout-standard).theme-dark .callout:is([data-callout=link], [data-callout=url]) :is(.callout-title-inner, .callout-icon svg) {
@@ -6929,16 +6929,16 @@ body:not(.callout-standard).theme-dark .callout:is([data-callout=link], [data-ca
 }
 
 body:not(.callout-standard) .callout:is([data-callout=phone]) {
-  --callout-color: 250, 121, 33;
+  --callout-color: rgb(250, 121, 33);
   --callout-icon: phone;
 }
 body:not(.callout-standard) .callout:is([data-callout=email],
 [data-callout=mail]) {
-  --callout-color: 250, 121, 33;
+  --callout-color: rgb(250, 121, 33);
   --callout-icon: at-sign;
 }
 body:not(.callout-standard) .callout:is([data-callout=goal]) {
-  --callout-color: 140, 102, 255;
+  --callout-color: rgb(140, 102, 255);
   --callout-icon: flag;
 }
 body:not(.callout-standard).theme-dark .callout:is([data-callout=goal]) :is(.callout-title-inner, .callout-icon svg) {
@@ -6947,16 +6947,16 @@ body:not(.callout-standard).theme-dark .callout:is([data-callout=goal]) :is(.cal
 
 body:not(.callout-standard) .callout:is([data-callout=plus],
 [data-callout=positive]) {
-  --callout-color: 50, 205, 50;
+  --callout-color: rgb(50, 205, 50);
   --callout-icon: plus;
 }
 body:not(.callout-standard) .callout:is([data-callout=minus],
 [data-callout=negative]) {
-  --callout-color: 124, 13, 14;
+  --callout-color: rgb(124, 13, 14);
   --callout-icon: minus;
 }
 body:not(.callout-standard) .callout:is([data-callout=code]) {
-  --callout-color: 0, 0, 0;
+  --callout-color: rgb(0, 0, 0);
   --callout-icon: code-2;
 }
 body:not(.callout-standard).theme-dark .callout:is([data-callout=code]) {
@@ -6974,7 +6974,7 @@ body:not(.callout-standard) .callout:is([data-callout=code]) .callout-content pr
   background-color: transparent;
 }
 body:not(.callout-standard) .callout:is([data-callout=success]) {
-  --callout-color: 0, 158, 76;
+  --callout-color: rgb(0, 158, 76);
   --callout-icon: star;
 }
 body:not(.callout-standard) .callout:is([data-callout=success]) :is(.callout-title-inner) {
@@ -7014,7 +7014,7 @@ body:not(.callout-standard):not(.no-animations) .callout:is([data-callout=succes
 }
 
 body:not(.callout-standard) .callout:is([data-callout=important]) {
-  --callout-color: 191, 63, 54;
+  --callout-color: rgb(191, 63, 54);
   --callout-icon: flag-triangle-right;
 }
 body:not(.callout-standard):not(.no-animations) .callout:is([data-callout=important]) .callout-title-inner {
@@ -7092,17 +7092,17 @@ body .callout:is([data-callout=columns]) {
   /* fallback option: grid */
   background-color: unset;
   margin-bottom: 0;
-  --callout-color: 150, 150, 150;
+  --callout-color: rgb(150, 150, 150);
   --callout-icon: columns;
 }
 body .callout:is([data-callout=columns]):hover {
-  border-left: 0rem solid rgb(var(--callout-color));
+  border-left: 0rem solid var(--callout-color);
 }
 body .callout:is([data-callout=columns]) > .callout-title {
   border-radius: calc(var(--shape-roundish) * 1.25);
 }
 body .callout:is([data-callout=columns]) > .callout-title:hover {
-  border-left: 0.3rem solid rgb(var(--callout-color));
+  border-left: 0.3rem solid var(--callout-color);
   transition: var(--quick-transition);
 }
 body .callout:is([data-callout=columns]) > .callout-content {
@@ -7470,7 +7470,7 @@ Version: 0.1.0
 div.callout[data-callout*=kanban] {
   border-left: 0;
   /* background-color: var(--background-primary); */
-  --callout-color: 100, 100, 100;
+  --callout-color: rgb(100, 100, 100);
   --callout-icon: star;
   /* not table, it uses rect instead of path */
   /* Willemstad specific? */
@@ -8419,7 +8419,7 @@ Last Updated: 2022-05-22
   display: flex;
   background-color: unset;
   gap: var(--gap-cornell-cssclass);
-  --callout-color: 0, 120, 0;
+  --callout-color: rgb(0, 120, 0);
 }
 .cornell .callout[data-callout^=cornell] p {
   margin-left: unset;

--- a/publish.css
+++ b/publish.css
@@ -2336,12 +2336,12 @@ span.cm-strong.cm-em.cm-highlight {
 
 /* opinionated stuff */
 body:not(.callout-standard) .callout {
-  border-left: 0rem solid rgb(var(--callout-color));
+  border-left: 0rem solid var(--callout-color);
   border-radius: calc(var(--shape-roundish) * 1.25);
   transition: var(--quick-transition);
 }
 body:not(.callout-standard) .callout:hover {
-  border-left: 0.3rem solid rgb(var(--callout-color));
+  border-left: 0.3rem solid var(--callout-color);
   transition: var(--quick-transition);
 }
 body:not(.callout-standard) .callout-title {
@@ -2521,16 +2521,16 @@ body:not(.callout-standard) {
   /* test stuff */
 }
 body:not(.callout-standard) .callout .callout-title {
-  background-color: rgba(var(--callout-color), 0.125);
+  background-color: color-mix(in srgb, var(--callout-color) 12.5%, transparent);
 }
 body:not(.callout-standard) .callout .callout-title-inner {
   /* opacity: 0.9; */
-  color: rgb(var(--callout-color));
+  color: var(--callout-color);
   -webkit-font-smoothing: antialiased;
 }
 body:not(.callout-standard) .callout:is([data-callout=note],
 [data-callout=aside]) {
-  --callout-color: 0, 191, 111;
+  --callout-color: rgb(0, 191, 111);
   /*
   & .callout-title-inner {
 
@@ -2549,16 +2549,16 @@ body:not(.callout-standard) .callout:is([data-callout=note],
 body:not(.callout-standard) .callout:is([data-callout=abstract],
 [data-callout=summary],
 [data-callout=tldr]) {
-  --callout-color: 91, 197, 219;
+  --callout-color: rgb(91, 197, 219);
   --callout-icon: loader;
 }
 body:not(.callout-standard) .callout:is([data-callout=info],
 [data-callout=todo]) {
-  --callout-color: 0, 170, 199;
+  --callout-color: rgb(0, 170, 199);
 }
 body:not(.callout-standard) .callout:is([data-callout=tip],
 [data-callout=hint]) {
-  --callout-color: 34, 148, 1;
+  --callout-color: rgb(34, 148, 1);
   --callout-icon: asterisk;
 }
 body:not(.callout-standard).theme-dark .callout:is([data-callout=tip], [data-callout=hint]) :is(.callout-title-inner, .callout-icon svg) {
@@ -2567,7 +2567,7 @@ body:not(.callout-standard).theme-dark .callout:is([data-callout=tip], [data-cal
 
 body:not(.callout-standard) .callout:is([data-callout=check],
 [data-callout=done]) {
-  --callout-color: 0, 158, 76;
+  --callout-color: rgb(0, 158, 76);
 }
 body:not(.callout-standard).theme-dark .callout:is([data-callout=check], [data-callout=done]) :is(.callout-title-inner, .callout-icon svg) {
   color: #00cc63;
@@ -2576,18 +2576,18 @@ body:not(.callout-standard).theme-dark .callout:is([data-callout=check], [data-c
 body:not(.callout-standard) .callout:is([data-callout=question],
 [data-callout=help],
 [data-callout=faq]) {
-  --callout-color: 160, 199, 92;
+  --callout-color: rgb(160, 199, 92);
 }
 body:not(.callout-standard) .callout:is([data-callout=warning],
 [data-callout=caution],
 [data-callout=attention]) {
-  /* --callout-color: 237, 183, 50; */
-  --callout-color: 255, 182, 26;
+  /* --callout-color: rgb(237, 183, 50); */
+  --callout-color: rgb(255, 182, 26);
 }
 body:not(.callout-standard) .callout:is([data-callout=failure],
 [data-callout=fail],
 [data-callout=missing]) {
-  --callout-color: 161, 40, 100;
+  --callout-color: rgb(161, 40, 100);
 }
 body:not(.callout-standard).theme-dark .callout:is([data-callout=failure], [data-callout=fail], [data-callout=missing]) :is(.callout-title-inner, .callout-icon svg) {
   color: #db70a6;
@@ -2595,21 +2595,21 @@ body:not(.callout-standard).theme-dark .callout:is([data-callout=failure], [data
 
 body:not(.callout-standard) .callout:is([data-callout=danger],
 [data-callout=error]) {
-  --callout-color: 241, 0, 34;
+  --callout-color: rgb(241, 0, 34);
 }
 body:not(.callout-standard).theme-dark .callout:is([data-callout=danger], [data-callout=error]) :is(.callout-title-inner, .callout-icon svg) {
   color: #ff334e;
 }
 
 body:not(.callout-standard) .callout:is([data-callout=bug]) {
-  --callout-color: 164, 103, 80;
+  --callout-color: rgb(164, 103, 80);
 }
 body:not(.callout-standard).theme-dark .callout:is([data-callout=bug]) :is(.callout-title-inner, .callout-icon svg) {
   color: #bc8976;
 }
 
 body:not(.callout-standard) .callout:is([data-callout=example]) {
-  --callout-color: 125, 84, 178;
+  --callout-color: rgb(125, 84, 178);
 }
 body:not(.callout-standard).theme-dark .callout:is([data-callout=example]) :is(.callout-title-inner, .callout-icon svg) {
   color: #a184c8;
@@ -2617,16 +2617,16 @@ body:not(.callout-standard).theme-dark .callout:is([data-callout=example]) :is(.
 
 body:not(.callout-standard) .callout:is([data-callout=quote],
 [data-callout=cite]) {
-  --callout-color: 161, 169, 173;
+  --callout-color: rgb(161, 169, 173);
 }
 body:not(.callout-standard) .callout:is([data-callout^=attachment],
 [data-callout^=file]) {
-  --callout-color: 197, 101, 199;
+  --callout-color: rgb(197, 101, 199);
   --callout-icon: paperclip;
 }
 body:not(.callout-standard) .callout:is([data-callout=link],
 [data-callout=url]) {
-  --callout-color: 127, 127, 127;
+  --callout-color: rgb(127, 127, 127);
   --callout-icon: link;
 }
 body:not(.callout-standard).theme-dark .callout:is([data-callout=link], [data-callout=url]) :is(.callout-title-inner, .callout-icon svg) {
@@ -2634,16 +2634,16 @@ body:not(.callout-standard).theme-dark .callout:is([data-callout=link], [data-ca
 }
 
 body:not(.callout-standard) .callout:is([data-callout=phone]) {
-  --callout-color: 250, 121, 33;
+  --callout-color: rgb(250, 121, 33);
   --callout-icon: phone;
 }
 body:not(.callout-standard) .callout:is([data-callout=email],
 [data-callout=mail]) {
-  --callout-color: 250, 121, 33;
+  --callout-color: rgb(250, 121, 33);
   --callout-icon: at-sign;
 }
 body:not(.callout-standard) .callout:is([data-callout=goal]) {
-  --callout-color: 140, 102, 255;
+  --callout-color: rgb(140, 102, 255);
   --callout-icon: flag;
 }
 body:not(.callout-standard).theme-dark .callout:is([data-callout=goal]) :is(.callout-title-inner, .callout-icon svg) {
@@ -2652,16 +2652,16 @@ body:not(.callout-standard).theme-dark .callout:is([data-callout=goal]) :is(.cal
 
 body:not(.callout-standard) .callout:is([data-callout=plus],
 [data-callout=positive]) {
-  --callout-color: 50, 205, 50;
+  --callout-color: rgb(50, 205, 50);
   --callout-icon: plus;
 }
 body:not(.callout-standard) .callout:is([data-callout=minus],
 [data-callout=negative]) {
-  --callout-color: 124, 13, 14;
+  --callout-color: rgb(124, 13, 14);
   --callout-icon: minus;
 }
 body:not(.callout-standard) .callout:is([data-callout=code]) {
-  --callout-color: 0, 0, 0;
+  --callout-color: rgb(0, 0, 0);
   --callout-icon: code-2;
 }
 body:not(.callout-standard).theme-dark .callout:is([data-callout=code]) {
@@ -2679,7 +2679,7 @@ body:not(.callout-standard) .callout:is([data-callout=code]) .callout-content pr
   background-color: transparent;
 }
 body:not(.callout-standard) .callout:is([data-callout=success]) {
-  --callout-color: 0, 158, 76;
+  --callout-color: rgb(0, 158, 76);
   --callout-icon: star;
 }
 body:not(.callout-standard) .callout:is([data-callout=success]) :is(.callout-title-inner) {
@@ -2719,7 +2719,7 @@ body:not(.callout-standard):not(.no-animations) .callout:is([data-callout=succes
 }
 
 body:not(.callout-standard) .callout:is([data-callout=important]) {
-  --callout-color: 191, 63, 54;
+  --callout-color: rgb(191, 63, 54);
   --callout-icon: flag-triangle-right;
 }
 body:not(.callout-standard):not(.no-animations) .callout:is([data-callout=important]) .callout-title-inner {
@@ -2797,17 +2797,17 @@ body .callout:is([data-callout=columns]) {
   /* fallback option: grid */
   background-color: unset;
   margin-bottom: 0;
-  --callout-color: 150, 150, 150;
+  --callout-color: rgb(150, 150, 150);
   --callout-icon: columns;
 }
 body .callout:is([data-callout=columns]):hover {
-  border-left: 0rem solid rgb(var(--callout-color));
+  border-left: 0rem solid var(--callout-color);
 }
 body .callout:is([data-callout=columns]) > .callout-title {
   border-radius: calc(var(--shape-roundish) * 1.25);
 }
 body .callout:is([data-callout=columns]) > .callout-title:hover {
-  border-left: 0.3rem solid rgb(var(--callout-color));
+  border-left: 0.3rem solid var(--callout-color);
   transition: var(--quick-transition);
 }
 body .callout:is([data-callout=columns]) > .callout-content {
@@ -3175,7 +3175,7 @@ Version: 0.1.0
 div.callout[data-callout*=kanban] {
   border-left: 0;
   /* background-color: var(--background-primary); */
-  --callout-color: 100, 100, 100;
+  --callout-color: rgb(100, 100, 100);
   --callout-icon: star;
   /* not table, it uses rect instead of path */
   /* Willemstad specific? */
@@ -4124,7 +4124,7 @@ Last Updated: 2022-05-22
   display: flex;
   background-color: unset;
   gap: var(--gap-cornell-cssclass);
-  --callout-color: 0, 120, 0;
+  --callout-color: rgb(0, 120, 0);
 }
 .cornell .callout[data-callout^=cornell] p {
   margin-left: unset;

--- a/theme.css
+++ b/theme.css
@@ -24750,12 +24750,13 @@ body:not(.ssopt-disable-alh) .mod-active :where(.markdown-source-view) .cm-activ
 body:not(.ssopt-disable-alh) .mod-active :where(.markdown-source-view) .cm-active.HyperMD-header::after {
   position: absolute;
   top: 0;
-  right: 0;
+  right: unset;
+  left: 0;
   bottom: 0;
   z-index: -1;
   width: 100vw;
   background-color: var(--col-background-activeline);
-  box-shadow: 100vw 0 0 0 var(--col-background-activeline);
+  box-shadow: -100vw 0 0 0 var(--col-background-activeline);
   content: "";
 }
 

--- a/theme.css
+++ b/theme.css
@@ -24754,9 +24754,11 @@ body:not(.ssopt-disable-alh) .mod-active :where(.markdown-source-view) .cm-activ
   left: 0;
   bottom: 0;
   z-index: -1;
-  width: 100vw;
+  width: 100%;
   background-color: var(--col-background-activeline);
-  box-shadow: -100vw 0 0 0 var(--col-background-activeline);
+  /* Extend the paint without extending CodeMirror's line or scroll geometry. */
+  box-shadow: 0 0 0 100vw var(--col-background-activeline);
+  clip-path: inset(0 -100vw);
   content: "";
 }
 


### PR DESCRIPTION
Completes the Obsidian 1.13 callout-colour migration in `obsidian.css` and `publish.css`, and keeps Active Line Highlighting within the editor's layout bounds. Related to #50, #71 and #72. The current `theme.css` colour migration is already in #80/#81.

## Reproduction

### Callout Colours

1. Use Obsidian 1.13+ with the compatibility `obsidian.css` stylesheet loaded as the theme, or test `publish.css` against the same complete-colour callout contract.
2. Render note, info, warning, success and example callouts. Inspect `--callout-color`: the old distributions still expose comma-separated RGB channels instead of a complete CSS colour.
3. Add this custom callout and snippet:

```md
> [!custom] Custom OKLCH colour
> The title should have the callout's tinted background.
```

```css
.callout[data-callout="custom"] {
  --callout-color: oklch(0.7 0.15 330);
}
```

4. Before the migration, wrapping this complete colour inside `rgb()`/`rgba()` makes the relevant declarations invalid. The custom title background is transparent. Afterward it renders with the intended 12.5% tint.

### Active Line Highlighting

1. In Source mode or Live Preview, leave Active Line Highlighting enabled and place the cursor in the middle of a line.
2. Press Home, or Cmd+Left on macOS, as described in #71/#72.
3. With the earlier version of this PR, also narrow the window or scroll horizontally: the left-anchored `100vw` pseudo-element extends beyond the actual line and introduces horizontal overflow.

The original first-Home failure was not reproduced on the tested Obsidian 1.13.7 Windows runtime. The earlier PR's horizontal-overflow regression was reproduced: a 346px editor had a 470px scroll area. The revised implementation preserves the intended left anchoring without this regression.

## Fix Principles

- Store complete `rgb(...)` colours and consume `var(--callout-color)` directly. Use `color-mix(in srgb, ..., transparent)` for the translucent title background.
- Give the highlight pseudo-element the current line's width. Extend only its paint with a spread shadow and a vertical clip, so highlighting reaches both page margins without creating a viewport-wide layout box. Preserve the separate table rule.
- No license or archived stylesheet source changes.

## Test Results

Real Obsidian 1.13.7 on Windows, isolated profiles and fixture notes:

- 12 callout distribution/revision/appearance cases, each covering six callout types. All patched callout variables are valid complete CSS colours; custom OKLCH titles regain their translucent background.
- Real Canvas renders custom `#dc45a0`, built-in red `#fb464c`, and built-in green `#44cf6e` nodes correctly.
- Home behavior matches the ALH-disabled control for 12 Source/Live Preview cases: heading, plain text, quote, code, another heading, and list.
- Horizontal overflow removed: 1836px to 1396px in a 1396px desktop editor; 470px to 346px in a 346px narrow editor. Highlight painting remains full width.
- All three stylesheets parse, `git diff --check` passes, and `LICENSE` is unchanged.

Evidence: [colour measurements](https://github.com/oldwinter/willemstad-x/blob/codex-willemstad-issue-evidence/verification/colour-compatibility-results.json), [keyboard and geometry measurements](https://github.com/oldwinter/willemstad-x/blob/codex-willemstad-issue-evidence/verification/keyboard-results.json).

Limits: native macOS Cmd+Left and native Android were not run. The narrow-window test uses the Windows renderer. `publish.css` was tested against Obsidian 1.13.7's actual renderer, not a separately deployed Publish site or older RGB-channel-based clients.

## Screenshots

| Case | Before | After |
| --- | --- | --- |
| Compatibility callouts | ![Old callout colours](https://raw.githubusercontent.com/oldwinter/willemstad-x/codex-willemstad-issue-evidence/verification/colours-obsidian.css-before.png) | ![Fixed callout colours](https://raw.githubusercontent.com/oldwinter/willemstad-x/codex-willemstad-issue-evidence/verification/colours-obsidian.css-after.png) |
| Earlier PR versus bounded highlight | ![Earlier narrow highlight](https://raw.githubusercontent.com/oldwinter/willemstad-x/codex-willemstad-issue-evidence/verification/keyboard-narrow-pr82-original.png) | ![Bounded narrow highlight](https://raw.githubusercontent.com/oldwinter/willemstad-x/codex-willemstad-issue-evidence/verification/keyboard-narrow-fixed.png) |

![Complete-colour Canvas nodes](https://raw.githubusercontent.com/oldwinter/willemstad-x/codex-willemstad-issue-evidence/verification/colours-canvas-after.png)
