### PR TITLE
Fix frosted status-bar contrast in cross-colour UI modes

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -24230,6 +24230,20 @@ body:is(.ssopt-status-bar-glass):not(.no-blur) .status-bar {
   --status-bar-background: transparent;
 }
 
+/* Frosted mini bars expose the editor beneath the cross-colour UI. */
+body:is(.ssopt-theme-contrast-light.theme-light, .ssopt-theme-contrast-dark.theme-dark).ssopt-status-bar-glass:not(.no-blur, .ssopt-status-bar-full, .ssopt-status-bar-glass-ui-colours) .status-bar {
+  --text-normal: inherit;
+  --text-muted: inherit;
+  --text-faint: inherit;
+  --background-modifier-hover: inherit;
+  --divider-color: inherit;
+  --icon-color: inherit;
+  --icon-color-hover: inherit;
+  --icon-color-focused: inherit;
+  --status-bar-text-color: var(--text-muted);
+  --status-bar-border-color: var(--divider-color);
+}
+
 .status-bar-item {
   line-height: var(--line-height-tight); /* overrides the 1 with 1.3 */
   padding: var(--elements-padding);
@@ -33536,6 +33550,14 @@ body:is(.ssopt-status-bar-glass):not(.no-blur) .setting-item.setting-item:where(
   display: grid;
 }
 
+.setting-item.setting-item:where([data-id="ssopt-status-bar-glass-ui-colours"]) {
+  display: none;
+}
+
+body:is(.ssopt-theme-contrast-light.theme-light, .ssopt-theme-contrast-dark.theme-dark).ssopt-status-bar-glass:not(.no-blur, .ssopt-status-bar-full) .setting-item.setting-item:where([data-id="ssopt-status-bar-glass-ui-colours"]) {
+  display: grid;
+}
+
 body:is(.ssopt-status-bar-full) .setting-item.setting-item:where([data-id="status-bar-align"], [data-id="ssopt-status-bar-float-not"], [data-id="status-bar-max-width"], [data-id="ssopt-status-bar-shift-workspace"]) {
   display: none;
 }
@@ -36493,6 +36515,11 @@ body:is(.ssopt-status-bar-float-not) .setting-item[data-id="ssopt-status-bar-gla
 body:is(.ssopt-status-bar-glass):not(.no-blur) .setting-item[data-id="ssopt-status-bar-borderless"] .setting-item-control::before {
   backdrop-filter: blur(var(--status-bar-glass-blur));
   background-color: unset;
+}
+
+body:is(.ssopt-theme-contrast-light.theme-light, .ssopt-theme-contrast-dark.theme-dark).ssopt-status-bar-glass:not(.no-blur, .ssopt-status-bar-full, .ssopt-status-bar-glass-ui-colours) :is(.setting-item[data-id="ssopt-status-bar-glass"] .setting-item-info, .setting-item[data-id="ssopt-status-bar-borderless"] .setting-item-control)::before {
+  color: var(--text-muted);
+  border-color: var(--divider-color);
 }
 
 /* --------------------------------------------------------------------------------
@@ -46190,6 +46217,14 @@ settings:
             document: DV01-StatusBar
             notes: (Requires 'No Blur Backdrop Filter' deactivated) 
             description: "When enabled, the status bar will adopt a frosted glass aesthetic."
+            default: false
+    -
+            id: ssopt-status-bar-glass-ui-colours
+            title: Use Sidebar Colours for Frosted Status Bar
+            type: class-toggle
+            document: DV01-StatusBar
+            notes: (Requires a cross-colour UI and a frosted mini status bar)
+            description: "Frosted status bars use the editor's text and border colours by default. Enable this when the bar sits over a sidebar to use the contrasting UI colours instead."
             default: false
     -
             id: status-bar-glass-blur

--- a/theme.css
+++ b/theme.css
@@ -46221,10 +46221,14 @@ settings:
     -
             id: ssopt-status-bar-glass-ui-colours
             title: Use Sidebar Colours for Frosted Status Bar
+            title.zh: "毛玻璃状态栏使用侧边栏配色"
+            title.zh-TW: "毛玻璃狀態列使用側邊欄配色"
             type: class-toggle
             document: DV01-StatusBar
             notes: (Requires a cross-colour UI and a frosted mini status bar)
             description: "Frosted status bars use the editor's text and border colours by default. Enable this when the bar sits over a sidebar to use the contrasting UI colours instead."
+            description.zh: "毛玻璃状态栏默认使用编辑器的文本和边框颜色。若状态栏覆盖侧边栏，启用此项可改用对比界面配色。"
+            description.zh-TW: "毛玻璃狀態列預設使用編輯器的文本和邊框顏色。若狀態列覆蓋側邊欄，啟用此項可改用對比介面配色。"
             default: false
     -
             id: status-bar-glass-blur


### PR DESCRIPTION
# Fix frosted status-bar contrast in cross-colour UI modes

Fixes #66.

The frosted mini status bar now uses the editor's text, icon, hover, and border colours. A contextual **Use Sidebar Colours for Frosted Status Bar** option preserves the contrasting UI palette when a right-aligned bar sits over a sidebar. Both RealDisplay previews follow the selection.

The new control includes Simplified and Traditional Chinese title/description metadata, so it remains localized when combined with #89.

## Reproduction

1. Use Willemstad from upstream `a8bd0eb` in a fresh Obsidian vault with the Style Settings plugin.
2. Select the light theme and enable **Enable Contrast** under its cross-colour UI settings.
3. Under **Status Bar**, select **Mini** with centre alignment and enable **Frosted Glass Aesthetic**. Keep blur at its default 4 px.
4. Open a short note so the floating bar sits over the plain editor background.
5. Repeat with the dark theme and its **Enable Contrast** option.

Before the fix, the transparent bar retains the opposite palette's text colour: light-mode text is almost white on a light editor, while dark-mode text is dark on a dark editor. Solid status bars use an opaque opposite-palette background, so their original colours are appropriate.

## Cause And Fix

The cross-colour UI rules remap neutral colours on `.status-bar`, and the frosted-glass rule independently changes its background to transparent. The text therefore contrasts with an opaque UI background that is no longer painted.

For frosted mini bars, inherit the editor-side neutral variables from the app container and map status-bar text and border colours to those inherited values. Retain the existing cross-colour mapping for solid bars, full-width bars, disabled blur, and the explicit sidebar-colour option. The new option is visible only when it applies.

## Validation

- Real Obsidian 1.13.7 on Windows, using a dedicated test vault and private profile: 20 before/after measurements across light/dark mode, frosted, sidebar colours, solid, full-width, and no-blur variants.
- Light frosted text: `oklch(0.8 0 0)` before, `oklch(0.3 0 0)` after, matching editor text.
- Dark frosted text: `oklch(0.42 0 0)` before, `oklch(0.68 0 0)` after, matching editor text.
- Asserted that all bar bounds and blur values stayed unchanged. Asserted that solid/full/no-blur/sidebar-colour variants retain their original text, background, and border colours.
- 24 Chromium/WebKit cases passed for option visibility and both RealDisplay previews. CSS and the affected Style Settings YAML block parse successfully; `git diff --check` passes.
- Automated tests applied the same body classes emitted by Style Settings; the public plugin UI was not the source of those automated class changes.

## Screenshots

| Mode | Before | After |
| --- | --- | --- |
| Light | ![Light before](https://raw.githubusercontent.com/oldwinter/willemstad-x/codex-willemstad-issue-evidence/verification/ui/66-before-real-light.png) | ![Light after](https://raw.githubusercontent.com/oldwinter/willemstad-x/codex-willemstad-issue-evidence/verification/ui/66-after-real-light.png) |
| Dark | ![Dark before](https://raw.githubusercontent.com/oldwinter/willemstad-x/codex-willemstad-issue-evidence/verification/ui/66-before-real-dark.png) | ![Dark after](https://raw.githubusercontent.com/oldwinter/willemstad-x/codex-willemstad-issue-evidence/verification/ui/66-after-real-dark.png) |

Measured results: [desktop matrix](https://github.com/oldwinter/willemstad-x/blob/codex-willemstad-issue-evidence/verification/ui/ui-real-results.json) and [Style Settings/RealDisplay matrix](https://github.com/oldwinter/willemstad-x/blob/codex-willemstad-issue-evidence/verification/ui/66-style-settings-results.json).

Only active `theme.css` changes. No archived theme version or proprietary Obsidian source is included.
