### PR TITLE
Tint translucent window chrome with the selected palette

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -1407,6 +1407,7 @@ pax, and tmp variables, which will be defined in other files/stylesheets.
   --background-primary-alt: var(--color-base-10);
   --background-secondary: var(--color-base-20);
   --background-secondary-alt: var(--color-base-25);
+  --workspace-background-translucent: oklch(from var(--background-secondary) l c h / 60%);
   --interactive-normal: var(--color-base-20);
   --interactive-hover: var(--color-base-30);
   --interactive-focus: var(--color-base-40);
@@ -1432,6 +1433,7 @@ pax, and tmp variables, which will be defined in other files/stylesheets.
   --background-primary-alt: var(--color-base-10);
   --background-secondary: var(--color-base-20);
   --background-secondary-alt: var(--color-base-25);
+  --workspace-background-translucent: oklch(from var(--background-secondary) l c h / 60%);
   --interactive-normal: var(--color-base-20);
   --interactive-hover: var(--color-base-30);
   --interactive-focus: var(--color-base-40);
@@ -22405,6 +22407,7 @@ body:is(.ssopt-theme-contrast-light.theme-light, .ssopt-theme-contrast-dark.them
 
 body:is(.ssopt-theme-contrast-light.theme-light, .ssopt-theme-contrast-dark.theme-dark) {
   --mobile-sidebar-background: var(--opp-background-primary);
+  --workspace-background-translucent: oklch(from var(--opp-background-secondary) l c h / 60%);
   --titlebar-background: var(--opp-background-secondary);
   --titlebar-background-focused: var(--opp-background-secondary-alt);
   --titlebar-border-color: var(--opp-background-modifier-border);


### PR DESCRIPTION
# Tint translucent window chrome with the selected palette

Related to #79.

Translucent window chrome now uses the selected Willemstad UI palette instead of Obsidian's default monochrome tint. The native 60% opacity and transparent child surfaces are preserved. Cross-colour modes use the opposite UI palette consistently.

## Reproduction

1. Use Willemstad on macOS with Obsidian's translucent-window option enabled.
2. Select the dark theme. In Style Settings, use **Vivid** base lightness, **Hagia Sophia** base tone, and **Nebula** accent, matching the issue report.
3. Compare the windowed titlebar and sidebars with the fullscreen view.
4. Repeat with a different base tone or the light theme. For cross-colour mode, enable **Enable Contrast**, optionally also importing the other mode's base colours.

Before the change, windowed chrome can lose the selected palette because the translucent rendering path uses Obsidian's neutral background tint. Fullscreen takes the ordinary themed backgrounds.

## Cause And Fix

Obsidian's `.is-translucent:not(.is-fullscreen)` rules make workspace children transparent and paint the titlebar/app container using `--workspace-background-translucent`. Willemstad maps the ordinary UI backgrounds but leaves this variable at Obsidian's monochrome default.

Map it to a 60%-opaque version of `--background-secondary` in light and dark modes. Use `--opp-background-secondary` in cross-colour modes. This changes only the tint source and leaves the native translucent/fullscreen selectors intact.

## Validation

- 72 before/after cases passed in a real Obsidian 1.13.7 Windows renderer: light/dark, Hagia Sophia/Tropical Lagoon palettes, normal/inverted/imported cross-colour modes, and opaque/translucent/fullscreen window classes.
- Every translucent case uses the expected palette hue/chroma/lightness with alpha 0.6. For Vivid/Hagia Sophia dark mode, the titlebar/app tint changes from `oklch(0 0 none / 0.6)` to `oklch(0.26 0.05 295 / 0.6)`.
- Asserted that all native transparent workspace child surfaces remain transparent.
- Asserted that all measured opaque-window and fullscreen backgrounds are identical before and after.
- `git diff --check` passes; only three variable mappings in active `theme.css` change.

## Screenshots And Platform Limit

The screenshots below are from a real Windows Obsidian renderer with macOS/translucency/fullscreen body classes. They demonstrate the CSS cascade and selected tint; they do not simulate native macOS vibrancy or desktop-background compositing.

| Mode | Before | After |
| --- | --- | --- |
| Dark | ![Dark before](https://raw.githubusercontent.com/oldwinter/willemstad-x/codex-willemstad-issue-evidence/verification/ui/79-before-tint-dark-real-renderer.png) | ![Dark after](https://raw.githubusercontent.com/oldwinter/willemstad-x/codex-willemstad-issue-evidence/verification/ui/79-after-tint-dark-real-renderer.png) |
| Light | ![Light before](https://raw.githubusercontent.com/oldwinter/willemstad-x/codex-willemstad-issue-evidence/verification/ui/79-before-tint-light-real-renderer.png) | ![Light after](https://raw.githubusercontent.com/oldwinter/willemstad-x/codex-willemstad-issue-evidence/verification/ui/79-after-tint-light-real-renderer.png) |

Measured results: [72-case tint matrix](https://github.com/oldwinter/willemstad-x/blob/codex-willemstad-issue-evidence/verification/ui/79-tint-results.json).

Native macOS visual confirmation remains needed. Translucent windows intentionally retain 60% opacity, so their final appearance still depends on the desktop/backdrop and is not guaranteed to be pixel-identical to an opaque fullscreen window.
