### PR TITLE
Add no-icon callout metadata and preserve Cornell inline layout

### DIFF
--- a/docs/callout-no-icon.md
+++ b/docs/callout-no-icon.md
@@ -1,0 +1,27 @@
+# Callouts Without Icons
+
+Add `no-icon` after the callout type to hide its icon while keeping the title:
+
+```md
+> [!note|no-icon] A title without an icon
+> The callout body is unchanged.
+```
+
+Separate metadata keywords with spaces to combine them:
+
+```md
+> [!note|no-bg no-icon] A title without a background or icon
+> Both metadata options apply.
+```
+
+`no-icon` hides only the current callout's title icon. Nested callouts keep their
+own icons unless they also use `no-icon`. Collapsible callouts retain their fold
+control and can still be expanded by clicking the title. To hide the entire title,
+use the existing `no-title` metadata instead.
+
+Supported in Live Preview, Reading mode, and `publish.css`.
+
+In notes with `cssclasses: cornell`, combine the Cornell `inline` keyword with
+`no-icon` as `> [!note|inline no-icon] Title`. The current theme keeps the same
+Cornell alignment as `inline` alone, including in print. Outside Cornell notes,
+`inline` does not enable a separate inline-callout layout.

--- a/obsidian.css
+++ b/obsidian.css
@@ -6721,6 +6721,9 @@ body:not(.callout-standard) svg.ChevronDown > * {
 \ Global Classes + Metadata
 ──────────────────────────────────────────────────────────────────────────────── */
 /* no title */
+body div.callout[data-callout-metadata~="no-icon"] > .callout-title > .callout-icon {
+  display: none;
+}
 body div.callout:is([data-callout-metadata*=no-t],
 [data-callout-metadata*=no-title]) > .callout-title {
   display: none;

--- a/publish.css
+++ b/publish.css
@@ -2426,6 +2426,9 @@ body:not(.callout-standard) svg.ChevronDown > * {
 \ Global Classes + Metadata
 ──────────────────────────────────────────────────────────────────────────────── */
 /* no title */
+body div.callout[data-callout-metadata~="no-icon"] > .callout-title > .callout-icon {
+  display: none;
+}
 body div.callout:is([data-callout-metadata*=no-t],
 [data-callout-metadata*=no-title]) > .callout-title {
   display: none;

--- a/theme.css
+++ b/theme.css
@@ -30785,6 +30785,10 @@ body:not(.ssopt-callout-standard) .callout[data-callout="code"] .callout-content
   }
 }
 
+body div.callout[data-callout-metadata~="no-icon"] > .callout-title > .callout-icon {
+  display: none;
+}
+
 body div.callout:is([data-callout-metadata*="no-t"], [data-callout-metadata*="no-title"]) > .callout-title {
   display: none;
 }
@@ -49995,7 +49999,7 @@ body {
   text-align: var(--cssc-cornell-text-align);
 }
 
-.cornell .callout[data-callout-metadata="inline"] {
+.cornell .callout[data-callout-metadata~="inline"] {
   margin-left: calc(var(--cssc-cornell-align-left) + var(--cssc-cornell-gap));
 }
 
@@ -50040,11 +50044,11 @@ body {
   float: unset;
 }
 
-.markdown-source-view.mod-cm6.cornell .callout[data-callout-metadata="inline"] {
+.markdown-source-view.mod-cm6.cornell .callout[data-callout-metadata~="inline"] {
   margin-left: unset;
 }
 
-.print .cornell > div > .callout[data-callout-metadata="inline"],
+.print .cornell > div > .callout[data-callout-metadata~="inline"],
 .print .cornell > div > h1, .print .cornell > div > h2, .print .cornell > div > h3, .print .cornell > div > h4, .print .cornell > div > h5, .print .cornell > div > h6, .print .cornell > div > hr,
 .print .cornell > div > pre, .print .cornell > div > blockquote, .print .cornell > div > ol, .print .cornell > div > ul, .print .cornell > div > table {
   margin-left: calc(var(--cssc-cornell-align-left) + var(--cssc-cornell-gap));


### PR DESCRIPTION
Fixes #69.

Adds `no-icon` to global callout metadata. It hides only the current callout's title icon, preserving its title, content, folding control, and nested callout icons. Cornell `inline` metadata can now be combined with other keywords without losing its alignment. Examples are in [the guide](https://github.com/oldwinter/willemstad-x/blob/codex-willemstad-no-icon/docs/callout-no-icon.md).

## Reproduction

1. Install upstream `a8bd0eb` in an Obsidian vault and select Willemstad.
2. Create a note containing the following and view it in Live Preview and Reading mode:

```md
> [!note|no-icon] Keep the title
> Hide only the icon.

> [!note|no-bg no-icon] Combined metadata
> Both options should apply.

> [!note|no-icon]- Foldable title
> The fold control should still work.
```

3. Before the change, the title icons remain visible because `no-icon` has no rule.
4. For the composition regression, add `cssclasses: cornell` to a note's properties and compare callouts using `inline` and `inline no-icon`. Before the change, only the exact `inline` value receives Cornell alignment.

## Fix

Use a whitespace-token selector for `no-icon` and direct-child selectors for the title icon, avoiding inherited icon overrides that would affect nested callouts. Apply it to all three public CSS distributions. Change the current theme's three Cornell `inline` selectors from exact-value matching to whitespace-token matching, preserving combined metadata in editing, reading, and print styling.

`inline` is a Cornell-specific keyword; this does not introduce a general inline layout outside Cornell notes.

## Test Results

- Real Obsidian 1.13.7 on Windows in an isolated test vault: 12 distribution/revision/view cases, 192 icon/title assertions, and four real title-click fold/unfold interactions passed.
- Confirmed normal icons and nested icons remain visible; `custom-no-icon` is not matched; existing `no-title` still hides the title; `no-bg no-icon` composes.
- Four before/after Cornell reading/print-class cases reproduce the alignment difference before and equal alignment after. Print checks exercise CSS print classes, not a generated PDF.
- All three changed stylesheets parse with PostCSS; `git diff --check` passes.
- [Full measured results](https://github.com/oldwinter/willemstad-x/blob/codex-willemstad-issue-evidence/verification/callout-results.json). Native macOS/iOS and an independently hosted Obsidian Publish site were not run; `publish.css` was loaded into the same real Obsidian renderer for its compatibility checks.

## Screenshots

| Case | Before | After |
| --- | --- | --- |
| Reading mode | ![Callouts before](https://raw.githubusercontent.com/oldwinter/willemstad-x/codex-willemstad-issue-evidence/verification/callouts-reading-before.png) | ![Callouts after](https://raw.githubusercontent.com/oldwinter/willemstad-x/codex-willemstad-issue-evidence/verification/callouts-reading-after.png) |
| Cornell metadata | ![Cornell before](https://raw.githubusercontent.com/oldwinter/willemstad-x/codex-willemstad-issue-evidence/verification/callouts-cornell-before.png) | ![Cornell after](https://raw.githubusercontent.com/oldwinter/willemstad-x/codex-willemstad-issue-evidence/verification/callouts-cornell-after.png) |
