### PR TITLE
Restore reliable outline and Scroll to Top positioning

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -28150,14 +28150,12 @@ body:is(.ssopt-block-width-pdfembed) .app-container {
 .markdown-reading-view .markdown-preview-view {
   container-type: inline-size;
   container-name: reading-mode;
-  scroll-behavior: smooth;
 }
 
 /* Live Preview Container */
 .view-content .cm-scroller {
   container-type: inline-size;
   container-name: live-preview;
-  scroll-behavior: smooth;
 }
 
 /* 1. TABLES */


### PR DESCRIPTION
# Fix outline and Scroll to Top positioning by restoring native scroll control

Fixes #74. Fixes #78.

Outline navigation and Scroll to Top can stop before reaching their destination when browser smooth scrolling is active. Removing the theme's forced `scroll-behavior: smooth` from the editor and reading-view scroll containers lets Obsidian position the viewport correctly.

## Reproduction

Environment used: real Obsidian 1.13.7 on Windows, Willemstad at upstream `a8bd0eb`, a disposable vault, and Scroll to Top 2.1.6 for the plugin checks.

1. Launch a disposable Obsidian profile with smooth scrolling enabled. On Windows installations that suppress smooth scrolling by default, use `Obsidian.exe --user-data-dir=<fresh-test-profile> --enable-smooth-scrolling` and open a test vault.
2. Activate Willemstad and enable the core Outline plugin. Create a note with 80 headings cycling through H1/H2/H3 and six paragraphs per heading. The exact note can be generated in the test vault's developer console:

   ```js
   await app.vault.create('Scroll reproduction.md', Array.from({ length: 80 }, (_, i) =>
     `${'#'.repeat(i % 3 + 1)} Section ${String(i + 1).padStart(2, '0')}\n\n` +
     Array.from({ length: 6 }, (_, j) =>
       `Paragraph ${j + 1}: deterministic outline navigation fixture for section ${i + 1}.`
     ).join('\n\n')
   ).join('\n\n'));
   ```

3. Open the note in Source mode and click these Outline entries in order: 34, 04, 31, 07, 37, 16, 28, 01. Wait for scrolling to stop after each click. Repeat in Live Preview and Reading mode.
4. Before the fix, some destinations remain outside the viewport even though the editor selection moves. For example, after selecting Section 04, the source editor remains around Sections 32-34. After the fix, Section 04 appears in the viewport.
5. For #74, install and enable **Scroll to Top 2.1.6**. Click its bottom button, then its top button. In Source/Live Preview, place the cursor at Section 34, scroll away with the scrollbar, and click the cursor-position button. Repeat top/bottom in Reading mode; the plugin intentionally hides its cursor button there.
6. Before the fix, the plugin can stop partway through these moves. After the fix, top reaches scroll offset zero, bottom exposes the final paragraph, and the cursor-position button exposes the existing selection.

## Cause And Fix

Both scroll containers were given `scroll-behavior: smooth` alongside their block-width container declarations. When browser smooth scrolling is active, ordinary programmatic `scrollTop` assignments become asynchronous. Obsidian and CodeMirror also measure and adjust their virtualized content while navigating; the forced animation can be interrupted by those adjustments, leaving the target offscreen.

The fix removes the two `scroll-behavior` declarations. The computed value returns to `auto`, and Obsidian's own navigation APIs control the movement. The existing container-query declarations continue providing block-width functionality.

## Recorded Test Results

All visibility decisions below were made after scroll offsets stopped changing, not during animation.

| Real Obsidian 1.13.7 test | Before | After |
| --- | --- | --- |
| Default Windows configuration: 24 Outline jumps across three modes | 24/24 visible | 24/24 visible |
| `--enable-smooth-scrolling`: same 24 Outline jumps | 8/24 visible | 24/24 visible |
| Default configuration: 8 Scroll to Top actions across three modes | 8/8 passed | 8/8 passed |
| `--enable-smooth-scrolling`: same plugin actions | 1/8 passed | 8/8 passed |

- The recorded smooth-enabled Outline failures are 5 Source, 6 Live Preview, and 5 Reading targets. Counts can vary because the underlying failure involves renderer timing.
- A source-mode `scrollTop = 0` immediately read back as 4025 before the fix with smooth scrolling enabled; after the fix it read back as 0.
- A separate CodeMirror 6.43.11 fixture with the full Obsidian 1.13.7 CSS and actual theme heading-line classes reproduced 8/9 offscreen targets before, versus 9/9 visible after, after scrolling settled.
- Verified the official Scroll to Top plugin version, real button clicks, top offset, last-paragraph visibility, preserved cursor line 462, and the plugin's hidden cursor control in Reading mode.
- CSS parsing and `git diff --check` pass. The source change is exactly two deleted declarations in active `theme.css`.

The default local Windows configuration did not reproduce the bug because scroll positioning was immediate despite a computed `smooth` value. The explicit smooth-scrolling launch flag is part of the reproducible test configuration, and is disclosed here rather than attributing the failure to every Windows installation. Native macOS was not available for testing.

## Screenshots

All primary screenshots are from actual Obsidian windows using the explicitly smooth-enabled test profile.

| Action | Before | After |
| --- | --- | --- |
| Outline: Section 04 | ![Wrong outline destination](https://raw.githubusercontent.com/oldwinter/willemstad-x/codex-willemstad-issue-evidence/verification/scroll-source-before-forced-smooth.png) | ![Correct outline destination](https://raw.githubusercontent.com/oldwinter/willemstad-x/codex-willemstad-issue-evidence/verification/scroll-source-after-forced-smooth.png) |
| Scroll to Top button | ![Top action before](https://raw.githubusercontent.com/oldwinter/willemstad-x/codex-willemstad-issue-evidence/verification/scroll-plugin-source-before-top-forced-smooth.png) | ![Top action after](https://raw.githubusercontent.com/oldwinter/willemstad-x/codex-willemstad-issue-evidence/verification/scroll-plugin-source-after-top-forced-smooth.png) |

## Reproducible Evidence

The local verification suite retains both configurations and their measured positions:

- `navigation-tests.mjs` and `navigation-tests.mjs --smooth`: `navigation-results.json` and `navigation-results-forced-smooth.json`.
- `scroll-plugin-test.mjs` and `scroll-plugin-test.mjs --smooth`: `scroll-plugin-results.json` and `scroll-plugin-results-forced-smooth.json`.
- `scroll-cm-repro.mjs`: `scroll-cm-results.json`.

Published measurements: [Outline with smooth scrolling](https://github.com/oldwinter/willemstad-x/blob/codex-willemstad-issue-evidence/verification/navigation-results-forced-smooth.json), [Scroll to Top with smooth scrolling](https://github.com/oldwinter/willemstad-x/blob/codex-willemstad-issue-evidence/verification/scroll-plugin-results-forced-smooth.json), [default Outline](https://github.com/oldwinter/willemstad-x/blob/codex-willemstad-issue-evidence/verification/navigation-results.json), [default plugin](https://github.com/oldwinter/willemstad-x/blob/codex-willemstad-issue-evidence/verification/scroll-plugin-results.json), and [CodeMirror fixture](https://github.com/oldwinter/willemstad-x/blob/codex-willemstad-issue-evidence/verification/scroll-cm-results.json).
