### PR TITLE
Add Simplified and Traditional Chinese Style Settings translations

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -9141,23 +9141,35 @@ settings:
     -
         id: info-re-theme-documentation
         title: Theme Documentation
+        title.zh: "主题文档"
+        title.zh-TW: "主題文件"
         description: willemstad.cc
+        description.zh: "willemstad.cc"
+        description.zh-TW: "willemstad.cc"
         type: class-toggle
         default: false
     -
         id: download-settings-search
         title: Please install the 'Settings Search' plugin by javalent to find settings faster.
+        title.zh: "安装 javalent 的 Settings Search 插件，可更快查找设置。"
+        title.zh-TW: "安裝 javalent 的 Settings Search 外掛，可更快查詢設定。"
         type: class-toggle
         default: false
     -
         id: warning-cm6-only
         title: "Please note that Willemstad is only supported on the default (non-legacy) editor on desktop at the moment. Mobile support will be rolled out at a later date."
+        title.zh: "Willemstad 目前仅支持桌面端的默认编辑器（非旧版编辑器），移动端支持将在之后提供。"
+        title.zh-TW: "Willemstad 目前僅支援桌面端的預設編輯器（非舊版編輯器），行動版支援將在之後提供。"
         type: class-toggle
         default: false
     -
         id: col-palette
         title: "Colour Palettes"
+        title.zh: "配色方案"
+        title.zh-TW: "配色方案"
         description: "Choose a colour palette!"
+        description.zh: "选择配色方案。"
+        description.zh-TW: "選擇配色方案。"
         type: class-select
         allowEmpty: false
         default: cp-classic-lshtm
@@ -9174,7 +9186,11 @@ settings:
     -
         id: font-pairings
         title: Font Pairings + Enable Custom Fonts
+        title.zh: "字体搭配与自定义字体"
+        title.zh-TW: "字型搭配與自訂字型"
         description: 'There are two suggested font typeface pairings with Willemstad, available here.'
+        description.zh: "Willemstad 提供两组推荐字体搭配，可在此选择。"
+        description.zh-TW: "Willemstad 提供兩組推薦字型搭配，可在此選擇。"
         type: class-select
         allowEmpty: false
         default: fp-manDM
@@ -9192,81 +9208,131 @@ settings:
     -
         id: true-black
         title: "True Black mode"
+        title.zh: "纯黑模式"
+        title.zh-TW: "純黑模式"
         type: class-toggle
         description: "When enabled, this makes the dark mode True Black."
+        description.zh: "启用后，深色模式使用纯黑背景。"
+        description.zh-TW: "啟用後，深色模式使用純黑背景。"
         default: false
     -
         id: no-animations
         title: No Animations
+        title.zh: "禁用动画"
+        title.zh-TW: "停用動畫"
         type: class-toggle
         description: "When enabled, this disables all animations in this theme."
+        description.zh: "启用后，禁用本主题的所有动画。"
+        description.zh-TW: "啟用後，停用本主題的所有動畫。"
         default: false
     -
         id: icons-obsidian-standard
         title: Use Standard Obsidian Icons
+        title.zh: "使用 Obsidian 标准图标"
+        title.zh-TW: "使用 Obsidian 標準圖示"
         type: class-toggle
         description: "When enabled, this replaces the custom Willemstad icon set with the standard Obsidian icons."
+        description.zh: "启用后，用 Obsidian 标准图标替换 Willemstad 自定义图标。"
+        description.zh-TW: "啟用後，用 Obsidian 標準圖示替換 Willemstad 自訂圖示。"
         default: false
     -
     -
         id: theme-willemstad
         title: Willemstad-Specific Class
+        title.zh: "Willemstad 专用类"
+        title.zh-TW: "Willemstad 專用類"
         description: willemstad.cc (should not be visible)
+        description.zh: "willemstad.cc（此项不应显示）"
+        description.zh-TW: "willemstad.cc（此項不應顯示）"
         type: class-toggle
         default: true
     -
     -
         id: startup
         title: Startup Screen
+        title.zh: "启动画面"
+        title.zh-TW: "啟動畫面"
         type: heading
         description: Startup Background Image, Dotted Grid Overlay, Loading Message Prefix, Gradient Startup Progress Bar
+        description.zh: "启动背景图片、圆点网格、加载信息前缀和渐变启动进度条。"
+        description.zh-TW: "啟動背景圖片、圓點網格、載入資訊字首和漸變啟動進度條。"
         level: 2
         collapsed: true
     -
             id: startup-devolution
             title: Disable Startup Screen Customisation
+            title.zh: "禁用启动画面自定义"
+            title.zh-TW: "停用啟動畫面自訂"
             type: class-toggle
             description: "Willemstad changes the startup screen by default, and multiple options to customise the startup screen. Toggle this to disable the customisation."
+            description.zh: "Willemstad 默认自定义启动画面，并提供多种调整选项。启用此项可停用自定义启动画面。"
+            description.zh-TW: "Willemstad 預設自訂啟動畫面，並提供多種調整選項。啟用此項可停用自訂啟動畫面。"
             default: false
     -
             id: bg-start-light
             title: Choose your Startup Background Image (Light mode)
+            title.zh: "选择启动背景图片（浅色模式）"
+            title.zh-TW: "選擇啟動背景圖片（淺色模式）"
             type: variable-text
             description: "Enter your own image (using a URL), or preferred background colour, or gradient. It's all up to you!"
+            description.zh: "可填入自选图片的 URL、背景色或渐变。"
+            description.zh-TW: "可填入自選圖片的 URL、背景色或漸變。"
             default: "url(https://images.unsplash.com/photo-1547628641-ec2098bb5812?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8.webp)"
     -
             id: bg-start-dark
             title: Choose your Startup Background Image (Dark mode)
+            title.zh: "选择启动背景图片（深色模式）"
+            title.zh-TW: "選擇啟動背景圖片（深色模式）"
             type: variable-text
             description: "Enter your own image (using a URL), or preferred background colour, or gradient. It's all up to you!"
+            description.zh: "可填入自选图片的 URL、背景色或渐变。"
+            description.zh-TW: "可填入自選圖片的 URL、背景色或漸變。"
             default: "url(https://images.unsplash.com/photo-1644773741876-e5f43ac020ce?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8.webp)"
     -
             id: startup-grid-hide
             title: Disable Dotted Grid Overlay to the Startup Screen
+            title.zh: "禁用启动画面的圆点网格"
+            title.zh-TW: "停用啟動畫面的圓點網格"
             type: class-toggle
             description: "A dotted grid overlay to the startup screen is applied by default in Willemstad. Toggle to disable this."
+            description.zh: "Willemstad 默认为启动画面添加圆点网格。启用此项可移除网格。"
+            description.zh-TW: "Willemstad 預設為啟動畫面新增圓點網格。啟用此項可移除網格。"
             default: false
     -
             id: startup-message-before-hide
             title: Disable Loading Message Prefix
+            title.zh: "禁用加载信息前缀"
+            title.zh-TW: "停用載入資訊字首"
             type: class-toggle
             description: "A customised message before the loading message is applied by default in Willemstad. Toggle to disable this."
+            description.zh: "Willemstad 默认在加载信息前添加自定义文本。启用此项可移除前缀。"
+            description.zh-TW: "Willemstad 預設在載入資訊前新增自訂文本。啟用此項可移除字首。"
             default: false
     -
             id: message-startup
             title: Loading Message Prefix — Text
+            title.zh: "加载信息前缀文本"
+            title.zh-TW: "載入資訊字首文本"
             type: variable-text
             description: "Enter your own loading message prefix here."
+            description.zh: "在此输入自定义加载信息前缀。"
+            description.zh-TW: "在此輸入自訂載入資訊字首。"
             default: '"Welcome back. "'
     -
             id: gradient-startup-bar
             title: Gradient Startup Progress Bar
+            title.zh: "渐变启动进度条"
+            title.zh-TW: "漸變啟動進度條"
             type: class-toggle
             description: "When enabled, the startup progress bar will have a gradient applied to it."
+            description.zh: "启用后，启动进度条使用渐变效果。"
+            description.zh-TW: "啟用後，啟動進度條使用漸變效果。"
             default: true
     -
             id: col-startup-1
             title: Gradient Startup Progress Bar — Colour
+            title.zh: "渐变启动进度条颜色"
+            title.zh-TW: "漸變啟動進度條顏色"
             type: variable-text
             description: 
             default: linear-gradient(258deg, hsl(60, 93%, 71%) 0%, hsl(98, 88%, 55%) 16%, hsl(122, 84%, 45%) 33%, hsl(138, 82%, 39%) 50%, hsl(155, 79%, 32%) 66%, hsl(171, 77%, 25%) 83%, hsl(184, 75%, 20%) 100%)
@@ -9274,15 +9340,23 @@ settings:
     -
         id: elements-ui-0
         title: 🌠 User Interface (UI) Elements
+        title.zh: "用户界面元素"
+        title.zh-TW: "使用者介面元素"
         description: 'Customise the UI elements here.'
+        description.zh: "在此自定义界面元素。"
+        description.zh-TW: "在此自訂介面元素。"
         type: heading
         level: 1
         collapsed: false
     -
         id: tb
         title: Titlebar
+        title.zh: "标题栏"
+        title.zh-TW: "標題列"
         type: class-select
         description: Choose which titlebar style you would like to use for Obsidian.
+        description.zh: "选择 Obsidian 标题栏样式。"
+        description.zh-TW: "選擇 Obsidian 標題列樣式。"
         allowEmpty: false
         default: default
         options:
@@ -9298,25 +9372,39 @@ settings:
     -
         id: elements-tb
         title: Titlebar Customisation
+        title.zh: "标题栏自定义"
+        title.zh-TW: "標題列自訂"
         type: heading
         description: Customise the titlebar elements here.
+        description.zh: "在此自定义标题栏元素。"
+        description.zh-TW: "在此自訂標題列元素。"
         level: 2
         collapsed: true
     -
             id: tb-title-remove
             title: Remove Title
+            title.zh: "移除标题"
+            title.zh-TW: "移除標題"
             type: class-toggle
             description: When enabled, this removes the title from the titlebar.
+            description.zh: "启用后，移除标题栏中的标题。"
+            description.zh-TW: "啟用後，移除標題列中的標題。"
             default: false
     -
             id: tb-willemstad
             title: Remove Willemstad Version Numbering Suffix
+            title.zh: "移除 Willemstad 版本编号后缀"
+            title.zh-TW: "移除 Willemstad 版本編號字尾"
             type: class-toggle
             description: When enabled, the titlebar removes the suffixed Willemstad version number from the end of the Obsidian version number.
+            description.zh: "启用后，移除标题栏中 Obsidian 版本号后附加的 Willemstad 版本号。"
+            description.zh-TW: "啟用後，移除標題列中 Obsidian 版本號後附加的 Willemstad 版本號。"
             default: false        
     -
             id: col-titlebar
             title: Change Titlebar Colour
+            title.zh: "更改标题栏颜色"
+            title.zh-TW: "更改標題列顏色"
             type: variable-themed-color
             opacity: true
             format: hsl
@@ -9326,15 +9414,23 @@ settings:
     -
         id: elements-ui
         title: 🌠 User Interface (UI) Elements
+        title.zh: "用户界面元素"
+        title.zh-TW: "使用者介面元素"
         description: 'Customise the UI elements here.'
+        description.zh: "在此自定义界面元素。"
+        description.zh-TW: "在此自訂介面元素。"
         type: heading
         level: 1
         collapsed: false
     -
             id: sb
             title: Status Bar
+            title.zh: "状态栏"
+            title.zh-TW: "狀態列"
             type: class-select
             description: Choose which status bar you would like to use for Obsidian.
+            description.zh: "选择 Obsidian 状态栏样式。"
+            description.zh-TW: "選擇 Obsidian 狀態列樣式。"
             allowEmpty: false
             default: sb-conjuring
             options:
@@ -9354,8 +9450,12 @@ settings:
     -
             id: sd
             title: Ribbon
+            title.zh: "侧边工具栏"
+            title.zh-TW: "側邊工具列"
             type: class-select
             description: Choose which ribbon/sidebar/side docks style you would like to use for Obsidian.
+            description.zh: "选择 Obsidian 的侧边工具栏、侧边栏与侧边面板样式。 选项含义：Floating Tabs — tabs that come into full-view when hovered：悬浮标签，悬停时完整显示；Styled Bars：自定义样式工具栏；Default Bars：默认工具栏；No Bars — hide all bars：隐藏所有工具栏。"
+            description.zh-TW: "選擇 Obsidian 的側邊工具列、側邊欄與側邊面板樣式。 選項含義：Floating Tabs — tabs that come into full-view when hovered：懸浮標籤，懸停時完整顯示；Styled Bars：自訂樣式工具列；Default Bars：預設工具列；No Bars — hide all bars：隱藏所有工具列。"
             allowEmpty: false
             default: sd-float-tabs
             options:
@@ -9374,15 +9474,23 @@ settings:
     -
             id: elements-sd
             title: Ribbon Customisation
+            title.zh: "侧边工具栏自定义"
+            title.zh-TW: "側邊工具列自訂"
             description: 'Customise the ribbon/sidebar elements here.'
+            description.zh: "在此自定义侧边工具栏和侧边栏元素。"
+            description.zh-TW: "在此自訂側邊工具列和側邊欄元素。"
             type: heading
             level: 2
             collapsed: true
     -
                 id: col-sd
                 title: 'Colours'
+                title.zh: "颜色"
+                title.zh-TW: "顏色"
                 type: variable-themed-color
                 description: 'Choose the colour you would like for your ribbons/sidebars. This affects the border colours for Styled Bars, and all colours for the Floating Tabs. Does not affect the default bars. [For Yellow — hsl(41, 100%, 55%)]' 
+                description.zh: "选择侧边工具栏与侧边栏颜色。影响 Styled Bars 的边框色以及 Floating Tabs 的全部配色，不影响默认工具栏。黄色可使用 hsl(41, 100%, 55%)。"
+                description.zh-TW: "選擇側邊工具列與側邊欄顏色。影響 Styled Bars 的邊框色以及 Floating Tabs 的全部配色，不影響預設工具列。黃色可使用 hsl(41, 100%, 55%)。"
                 opacity: true
                 format: hsl
                 default-light: hsl(184, 74%, 20%)
@@ -9390,27 +9498,43 @@ settings:
     -
                 id: ribbon-action-align-centre
                 title: Centre Ribbon Action Buttons
+                title.zh: "侧边工具栏操作按钮垂直居中"
+                title.zh-TW: "側邊工具列操作按鈕垂直居中"
                 type: class-toggle
                 description: "When enabled, the Ribbon Action buttons (on the left ribbon/sidebar) will be vertically centered."
+                description.zh: "启用后，左侧工具栏中的操作按钮垂直居中。"
+                description.zh-TW: "啟用後，左側工具列中的操作按鈕垂直居中。"
                 default: false
     -
                 id: custom-ft
                 title: 'Customisation — Floating Tabs'
+                title.zh: "悬浮标签自定义"
+                title.zh-TW: "懸浮標籤自訂"
                 description: 'If you have selected the Floating Tabs option in the Ribbon style setting, customise the Floating Tabs here.'
+                description.zh: "在工具栏样式中选择 Floating Tabs 后，可在此自定义悬浮标签。"
+                description.zh-TW: "在工具列樣式中選擇 Floating Tabs 後，可在此自訂懸浮標籤。"
                 type: heading
                 level: 3
                 collapsed: false
     -
                     id: sd-opacity-none
                     title: 'Disappearing Floating Tabs'
+                    title.zh: "自动隐藏悬浮标签"
+                    title.zh-TW: "自動隱藏懸浮標籤"
                     type: class-toggle
                     description: 'If toggled, Floating Tabs will disappear when not hovered.'
+                    description.zh: "启用后，悬浮标签在未悬停时自动隐藏。"
+                    description.zh-TW: "啟用後，懸浮標籤在未懸停時自動隱藏。"
                     default: false
     -
                     id: sd-height-norm
                     title: 'Floating Tab Height, when not hovered'
+                    title.zh: "悬浮标签高度（未悬停）"
+                    title.zh-TW: "懸浮標籤高度（未懸停）"
                     type: variable-number-slider
                     description: 'Set the height of the tabs for the Floating Tabs, when not hovered.'
+                    description.zh: "设置悬浮标签未悬停时的高度。"
+                    description.zh-TW: "設定懸浮標籤未懸停時的高度。"
                     format: 'rem'
                     default: 15
                     min: 5
@@ -9419,8 +9543,12 @@ settings:
     -
                     id: sd-height-hover
                     title: 'Floating Tab Height, when hovered'
+                    title.zh: "悬浮标签高度（悬停时）"
+                    title.zh-TW: "懸浮標籤高度（懸停時）"
                     type: variable-number-slider
                     description: 'Set the height of the tabs for the Floating Tabs, when hovered.'
+                    description.zh: "设置悬浮标签悬停时的高度。"
+                    description.zh-TW: "設定懸浮標籤懸停時的高度。"
                     format: '%'
                     default: 50
                     min: 5
@@ -9429,8 +9557,12 @@ settings:
     -
                     id: sd-width-norm
                     title: 'Floating Tab Width, when not hovered'
+                    title.zh: "悬浮标签宽度（未悬停）"
+                    title.zh-TW: "懸浮標籤寬度（未懸停）"
                     type: variable-number-slider
                     description: 'Set the width of the tabs for the Floating Tabs, when not hovered.'
+                    description.zh: "设置悬浮标签未悬停时的宽度。"
+                    description.zh-TW: "設定懸浮標籤未懸停時的寬度。"
                     format: 'rem'
                     default: 1.1
                     min: 0.7
@@ -9439,21 +9571,33 @@ settings:
     -
             id: elements-nav
             title: Navigation, Navigation Pane, Sidebar Panes and Sidebar Tabs
+            title.zh: "导航、导航面板、侧边面板与侧边栏标签页"
+            title.zh-TW: "導航、導航面板、側邊面板與側邊欄標籤頁"
             description: 'Customise the abovementioned elements here.'
+            description.zh: "在此自定义上述元素。"
+            description.zh-TW: "在此自訂上述元素。"
             type: heading
             level: 2
             collapsed: true
     -
             id: mobile-style-sidepanes
             title: Mobile-Style Floating Sidebar Panes
+            title.zh: "移动端风格的悬浮侧边面板"
+            title.zh-TW: "行動版風格的懸浮側邊面板"
             type: class-toggle
             description: "When enabled, the workspace pane will not move to acommodate the sidepanes; instead, the sidepanes will be displayed on top of the workspace pane."
+            description.zh: "启用后，侧边面板覆盖显示在工作区上方，工作区不再为侧边面板移动或让出空间。"
+            description.zh-TW: "啟用後，側邊面板覆蓋顯示在工作區上方，工作區不再為側邊面板移動或讓出空間。"
             default: false
     -
             id: opacity-mobile-style
             title: 'Opacity (Unhovered) — Mobile-Style Sidepanes'
+            title.zh: "移动端风格侧边面板不透明度（未悬停）"
+            title.zh-TW: "行動版風格側邊面板不透明度（未懸停）"
             type: variable-number-slider
             description: Use this setting to change the opacity of the sidepanes, when unhovered.
+            description.zh: "设置侧边面板未悬停时的不透明度。"
+            description.zh-TW: "設定側邊面板未懸停時的不透明度。"
             format: ''
             default: 0
             min: 0
@@ -9462,7 +9606,11 @@ settings:
     -
             id: transition-mobile-style
             title: 'Transition Speed — Mobile-Style Sidepanes'
+            title.zh: "移动端风格侧边面板过渡速度"
+            title.zh-TW: "行動版風格側邊面板過渡速度"
             description: "Use this setting to change the transition speed of the sidepanes from unhovered to hovered."
+            description.zh: "设置侧边面板从未悬停到悬停状态的过渡速度。 选项含义：Slow：慢；Medium：中等；Quick：快；Quicker：更快；No Transition：无过渡。"
+            description.zh-TW: "設定側邊面板從未懸停到懸停狀態的過渡速度。 選項含義：Slow：慢；Medium：中等；Quick：快；Quicker：更快；No Transition：無過渡。"
             type: variable-select
             default: var(--medium-transition)
             options:
@@ -9484,14 +9632,22 @@ settings:
     -
             id: no-nav-file-tag
             title: Remove Navigation File Tags
+            title.zh: "移除导航文件标签"
+            title.zh-TW: "移除導航檔案標籤"
             type: class-toggle
             description: When enabled, this removes the file tags from the navigation bar.
+            description.zh: "启用后，移除导航栏中的文件标签。"
+            description.zh-TW: "啟用後，移除導航欄中的檔案標籤。"
             default: false
     -
             id: size-font-nav
             title: Font Size — Navigation Pane
+            title.zh: "导航面板字号"
+            title.zh-TW: "導航面板字級"
             type: variable-number-slider
             description: Use this setting to change the font size of the navigation pane.
+            description.zh: "设置导航面板字号。"
+            description.zh-TW: "設定導航面板字級。"
             format: "em"
             default: 0.9
             min: 0.25
@@ -9500,8 +9656,12 @@ settings:
     -
             id: nav-buttons-align-L
             title: Navigation Buttons Alignment — Navigation Pane
+            title.zh: "导航面板按钮对齐方式"
+            title.zh-TW: "導航面板按鈕對齊方式"
             type: class-select
             description: "Choose the alignment of your navigation buttons on the navigation pane/left sidebar pane."
+            description.zh: "选择导航面板或左侧边面板中导航按钮的对齐方式。 选项含义：Left-aligned：左对齐；Centre-aligned：居中；Right-aligned：右对齐。"
+            description.zh-TW: "選擇導航面板或左側邊面板中導航按鈕的對齊方式。 選項含義：Left-aligned：左對齊；Centre-aligned：居中；Right-aligned：右對齊。"
             allowEmpty: false
             default: nav-buttons-left-L
             options:
@@ -9517,8 +9677,12 @@ settings:
     -
             id: nav-buttons-align-R
             title: Navigation Buttons Alignment — Right Sidebar Pane
+            title.zh: "右侧边面板导航按钮对齐方式"
+            title.zh-TW: "右側邊面板導航按鈕對齊方式"
             type: class-select
             description: "Choose the alignment of your navigation buttons on the right sidebar pane."
+            description.zh: "选择右侧边面板中导航按钮的对齐方式。 选项含义：Left-aligned：左对齐；Centre-aligned：居中；Right-aligned：右对齐。"
+            description.zh-TW: "選擇右側邊面板中導航按鈕的對齊方式。 選項含義：Left-aligned：左對齊；Centre-aligned：居中；Right-aligned：右對齊。"
             allowEmpty: false
             default: nav-buttons-right-R
             options:
@@ -9534,14 +9698,22 @@ settings:
     -
             id: show-sidebar-tabs
             title: "Show Sidebar Tabs"
+            title.zh: "显示侧边栏标签页"
+            title.zh-TW: "顯示側邊欄標籤頁"
             type: class-toggle
             description: "When enabled, the sidebar tabs will be displayed."
+            description.zh: "启用后，显示侧边栏标签页。"
+            description.zh-TW: "啟用後，顯示側邊欄標籤頁。"
             default: false
     -
             id: sb-tabs-align-L
             title: Sidebar Tabs Alignment — Left Sidebar Pane
+            title.zh: "左侧边面板标签页对齐方式"
+            title.zh-TW: "左側邊面板標籤頁對齊方式"
             type: class-select
             description: "Choose the alignment of your sidebar tabs on the navigation pane/left sidebar pane."
+            description.zh: "选择导航面板或左侧边面板中标签页的对齐方式。 选项含义：Left-aligned：左对齐；Centre-aligned：居中；Right-aligned：右对齐。"
+            description.zh-TW: "選擇導航面板或左側邊面板中標籤頁的對齊方式。 選項含義：Left-aligned：左對齊；Centre-aligned：居中；Right-aligned：右對齊。"
             allowEmpty: false
             default: sb-tabs-left-L
             options:
@@ -9557,8 +9729,12 @@ settings:
     -
             id: sb-tabs-align-R
             title: Sidebar Tabs Alignment — Right Sidebar Pane
+            title.zh: "右侧边面板标签页对齐方式"
+            title.zh-TW: "右側邊面板標籤頁對齊方式"
             type: class-select
             description: "Choose the alignment of your sidebar tabs on the right sidebar pane."
+            description.zh: "选择右侧边面板中标签页的对齐方式。 选项含义：Left-aligned：左对齐；Centre-aligned：居中；Right-aligned：右对齐。"
+            description.zh-TW: "選擇右側邊面板中標籤頁的對齊方式。 選項含義：Left-aligned：左對齊；Centre-aligned：居中；Right-aligned：右對齊。"
             allowEmpty: false
             default: sb-tabs-right-R
             options:
@@ -9574,19 +9750,29 @@ settings:
     -
             id: modals
             title: Modals
+            title.zh: "对话框"
+            title.zh-TW: "對話方塊"
             description: 'Change the widths and heights of modals (the settings/community plugins/themes/Publish menus).'
+            description.zh: "调整设置、社区插件、主题和 Publish 对话框的宽度与高度。"
+            description.zh-TW: "調整設定、社群外掛、主題和 Publish 對話方塊的寬度與高度。"
             type: heading
             level: 2
             collapsed: true
     -
                 id: remove-modal-cp-options-bold
                 title: "Disable Shimmering Focus-style Bold Typeface for Appearance, Hotkeys and Community Plugins options"
+                title.zh: "禁用外观、快捷键与社区插件选项的 Shimmering Focus 风格粗体"
+                title.zh-TW: "停用外觀、快捷鍵與社群外掛選項的 Shimmering Focus 風格粗體"
                 type: class-toggle
                 description: "Shimmering Focus's predilection for bolded Appearance, Hotkeys, and Community Plugins options in the Settings modal are applied in Willemstad by default. Toggle this to remove this specific bold styling."
+                description.zh: "Willemstad 默认采用 Shimmering Focus 的做法，将设置中的“外观”“快捷键”“社区插件”选项加粗。启用此项可移除此粗体样式。"
+                description.zh-TW: "Willemstad 預設採用 Shimmering Focus 的做法，將設定中的“外觀”“快捷鍵”“社群外掛”選項加粗。啟用此項可移除此粗體樣式。"
                 default: false
     -
             id: modal-widths
             title: Modal Widths
+            title.zh: "对话框宽度"
+            title.zh-TW: "對話方塊寬度"
             description:
             type: heading
             level: 3
@@ -9594,6 +9780,8 @@ settings:
     -
                 id: modal-width-settings
                 title: Modal Widths — Settings
+                title.zh: "对话框宽度：设置"
+                title.zh-TW: "對話方塊寬度：設定"
                 type: variable-number-slider
                 format: 'vw'
                 default: 70
@@ -9603,6 +9791,8 @@ settings:
     -
                 id: modal-width-community-plugin
                 title: Modal Widths — Community Plugin Store
+                title.zh: "对话框宽度：社区插件商店"
+                title.zh-TW: "對話方塊寬度：社群外掛商店"
                 type: variable-number-slider
                 format: 'vw'
                 default: 70
@@ -9612,6 +9802,8 @@ settings:
     -
                 id: modal-width-community-theme
                 title: Modal Widths — Theme Store
+                title.zh: "对话框宽度：主题商店"
+                title.zh-TW: "對話方塊寬度：主題商店"
                 type: variable-number-slider
                 format: 'vw'
                 default: 70
@@ -9621,6 +9813,8 @@ settings:
     -
                 id: modal-width-publish
                 title: Modal Widths — Publish
+                title.zh: "对话框宽度：Publish"
+                title.zh-TW: "對話方塊寬度：Publish"
                 type: variable-number-slider
                 format: 'vw'
                 default: 42
@@ -9631,6 +9825,8 @@ settings:
     -
             id: modal-heights
             title: Modal Heights
+            title.zh: "对话框高度"
+            title.zh-TW: "對話方塊高度"
             description:
             type: heading
             level: 3
@@ -9638,6 +9834,8 @@ settings:
     -
                 id: modal-height-settings
                 title: Modal Heights — Settings
+                title.zh: "对话框高度：设置"
+                title.zh-TW: "對話方塊高度：設定"
                 type: variable-number-slider
                 format: 'vh'
                 default: 70
@@ -9647,6 +9845,8 @@ settings:
     -
                 id: modal-height-community-plugin
                 title: Modal Heights — Community Plugin Store
+                title.zh: "对话框高度：社区插件商店"
+                title.zh-TW: "對話方塊高度：社群外掛商店"
                 type: variable-number-slider
                 format: 'vh'
                 default: 90
@@ -9656,6 +9856,8 @@ settings:
     -
                 id: modal-height-community-theme
                 title: Modal Heights — Theme Store
+                title.zh: "对话框高度：主题商店"
+                title.zh-TW: "對話方塊高度：主題商店"
                 type: variable-number-slider
                 format: 'vh'
                 default: 90
@@ -9665,6 +9867,8 @@ settings:
     -
                 id: modal-height-publish
                 title: Modal Heights — Publish
+                title.zh: "对话框高度：Publish"
+                title.zh-TW: "對話方塊高度：Publish"
                 type: variable-number-slider
                 format: 'vh'
                 default: 25
@@ -9680,6 +9884,8 @@ settings:
     -
             id: size-scrollbar
             title: Scrollbar Size
+            title.zh: "滚动条尺寸"
+            title.zh-TW: "捲軸尺寸"
             type: variable-number-slider
             format: "rem"
             default: 0.35
@@ -9689,8 +9895,12 @@ settings:
     -
             id: style-backlink
             title: Backlink Pane Styling
+            title.zh: "反向链接面板样式"
+            title.zh-TW: "反向連結面板樣式"
             type: class-toggle
             description: When toggled, this styles the backlink panes.
+            description.zh: "启用后，应用反向链接面板样式。"
+            description.zh-TW: "啟用後，應用反向連結面板樣式。"
             default: true
 */
 /* @settings
@@ -9700,25 +9910,41 @@ settings:
     -
         id: length-line-var
         title: Override Line Lengths
+        title.zh: "覆盖阅读行宽"
+        title.zh-TW: "覆蓋閱讀行寬"
         type: class-toggle
         description: "When enabled, this overrides the Readable Line Length core setting."
+        description.zh: "启用后，覆盖 Obsidian 核心的阅读行宽设置。"
+        description.zh-TW: "啟用後，覆蓋 Obsidian 核心的閱讀行寬設定。"
         default: false
     -
             id: width-vll
             title: Custom Maximum Line Length 
+            title.zh: "自定义最大行宽"
+            title.zh-TW: "自訂最大行寬"
             description: "Set the maximum line length. Accepts all valid CSS units."
+            description.zh: "设置最大行宽。接受有效的 CSS 单位。"
+            description.zh-TW: "設定最大行寬。接受有效的 CSS 單位。"
             type: variable-text
             default: 700px
     -
             id: fit-titles-vll
             title: Fit Titles to Line Length
+            title.zh: "标题宽度适应行宽"
+            title.zh-TW: "標題寬度適應行寬"
             description: "When enabled, this will fit titles to the editor line length."
+            description.zh: "启用后，标题宽度适应编辑器行宽。"
+            description.zh-TW: "啟用後，標題寬度適應編輯器行寬。"
             type: class-toggle
             default: false
     -
             id: document-title-display
             title: Document Title Display Options
+            title.zh: "文档标题显示选项"
+            title.zh-TW: "文件標題顯示選項"
             description: "Choose how (and whether) you want the document title displayed."
+            description.zh: "选择文档标题是否显示，以及显示方式。 选项含义：Standard (Left-aligned)：标准（左对齐）；Centered：居中；Right-aligned：右对齐；Hidden：隐藏。"
+            description.zh-TW: "選擇文件標題是否顯示，以及顯示方式。 選項含義：Standard (Left-aligned)：標準（左對齊）；Centered：居中；Right-aligned：右對齊；Hidden：隱藏。"
             type: class-select
             allowEmpty: false
             default: doc-title-align-l
@@ -9738,32 +9964,52 @@ settings:
     -
         id: frontmatter-options
         title: Frontmatter
+        title.zh: "Frontmatter"
+        title.zh-TW: "Frontmatter"
         type: heading
         level: 2
         description: Frontmatter options for Willemstad.
+        description.zh: "Willemstad 的 Frontmatter 选项。"
+        description.zh-TW: "Willemstad 的 Frontmatter 選項。"
         collapsed: true
     -
             id: yaml-no-colour
             title: Disable Coloured YAML
+            title.zh: "禁用彩色 YAML"
+            title.zh-TW: "停用彩色 YAML"
             type: class-toggle
             description: By default, the YAML frontmatter is coloured selectively to increase readabiity. Toggle this to disable this feature.
+            description.zh: "默认对 YAML Frontmatter 的不同部分着色以提高可读性。启用此项可禁用配色。"
+            description.zh-TW: "預設對 YAML Frontmatter 的不同部分著色以提高可讀性。啟用此項可停用配色。"
             default: false
     -
             id: size-font-frontmatter-header
             title: Font Size — Frontmatter Header
+            title.zh: "Frontmatter 标题字号"
+            title.zh-TW: "Frontmatter 標題字級"
             description: Accepts any valid CSS units.
+            description.zh: "接受有效的 CSS 单位。"
+            description.zh-TW: "接受有效的 CSS 單位。"
             type: variable-text
             default: 0.9em
     -
             id: size-font-frontmatter-section
             title: Font Size — Frontmatter Section (Aliases and Tags)
+            title.zh: "Frontmatter 区域字号（别名与标签）"
+            title.zh-TW: "Frontmatter 區域字級（別名與標籤）"
             description: Accepts any valid CSS units.
+            description.zh: "接受有效的 CSS 单位。"
+            description.zh-TW: "接受有效的 CSS 單位。"
             type: variable-texts
             default: 0.9em
     -
             id: frontmatter-display
             title: Frontmatter Display Options
+            title.zh: "Frontmatter 显示选项"
+            title.zh-TW: "Frontmatter 顯示選項"
             description: "Choose how (and whether) you want the frontmatter displayed. Works only for Reading mode."
+            description.zh: "选择 Frontmatter 是否显示，以及显示方式。仅适用于阅读模式。"
+            description.zh-TW: "選擇 Frontmatter 是否顯示，以及顯示方式。僅適用於閱讀模式。"
             type: class-select
             allowEmpty: false
             default: default
@@ -9784,100 +10030,146 @@ settings:
     -
         id: typography-typeface
         title: Font Typeface
+        title.zh: "字体"
+        title.zh-TW: "字型"
         type: heading
         description: Typeface options for Willemstad. For Longform and Writing CSSClass settings, please use the Longform-specific options in the Plugin Settings panel. Font settings set in core Obsidian will override the settings set here.
+        description.zh: "Willemstad 字体选项。Longform 和写作 CSSClass 请在插件设置面板的 Longform 专用区域调整。Obsidian 核心字体设置会覆盖此处的设置。"
+        description.zh-TW: "Willemstad 字型選項。Longform 和寫作 CSSClass 請在外掛設定面板的 Longform 專用區域調整。Obsidian 核心字型設定會覆蓋此處的設定。"
         level: 2
         collapsed: true
     -
             id: font-monospace-theme
             title: Font Typeface — Monospace
+            title.zh: "字体：等宽"
+            title.zh-TW: "字型：等寬"
             description:
             type: variable-text
             default: '"DM Mono"'
     -
             id: font-heading
             title: Font Typeface — Headers
+            title.zh: "字体：标题"
+            title.zh-TW: "字型：標題"
             description:
             type: variable-text
             default: '"DM Sans", "Inter 3.19", "Manrope"'
     -
             id: font-editor
             title: Font Typeface — Editor
+            title.zh: "字体：编辑器"
+            title.zh-TW: "字型：編輯器"
             description:
             type: variable-text
             default: '"DM Sans", "Inter 3.19", "Manrope"'
     -
             id: font-menu
             title: Font Typeface — Menu
+            title.zh: "字体：菜单"
+            title.zh-TW: "字型：選單"
             description:
             type: variable-text
             default: '"Manrope", "Inter 3.19", "DM Sans"'
     -
             id: font-ui
             title: Font Typeface — User Interface (UI)
+            title.zh: "字体：用户界面"
+            title.zh-TW: "字型：使用者介面"
             description:
             type: variable-text
             default: '"Manrope", "Inter 3.19", "DM Sans"'
     -
             id: font-editor-m
             title: Font Typeface — Mobile Editor
+            title.zh: "字体：移动端编辑器"
+            title.zh-TW: "字型：行動版編輯器"
             description:
             type: variable-text
             default: '"DM Sans", "Inter 3.19", "Manrope'
     -
             id: font-menu-m
             title: Font Typeface — Mobile Menu
+            title.zh: "字体：移动端菜单"
+            title.zh-TW: "字型：行動版選單"
             description:
             type: variable-text
             default: '"Manrope", "Inter 3.19", "DM Sans"'
     -
             id: font-ui-m
             title: Font Typeface — Mobile User Interface (UI)
+            title.zh: "字体：移动端用户界面"
+            title.zh-TW: "字型：行動版使用者介面"
             description:
             type: variable-text
             default: '"Manrope", "Inter 3.19", "DM Sans"'
     -
             id: font-mermaid
             title: "Font Typeface — Mermaid.js"
+            title.zh: "字体：Mermaid.js"
+            title.zh-TW: "字型：Mermaid.js"
             description: Changes font for the in-built Mermaid.js visualisations in the theme.
+            description.zh: "更改主题内置 Mermaid.js 图表的字体。"
+            description.zh-TW: "更改主題內建 Mermaid.js 圖表的字型。"
             type: variable-text
             default: '"DM Sans", "Inter 3.19", "Manrope"'
     -
         id: h-col
         title: Headers
+        title.zh: "标题"
+        title.zh-TW: "標題"
         type: heading
         description: Change settings for headers (H1–H6) here.
+        description.zh: "在此调整 H1-H6 标题设置。"
+        description.zh-TW: "在此調整 H1-H6 標題設定。"
         level: 2
         collapsed: true
     -
             id: no-smol-headers
             title: "Disable Smaller Header Hexes" 
+            title.zh: "禁用缩小标题井号"
+            title.zh-TW: "停用縮小標題井號"
             type: class-toggle
             description: "The header hex prefix (#) are smaller in Willemstad by default. Toggle this to disable this feature."
+            description.zh: "Willemstad 默认缩小标题前的井号（#）。启用此项可禁用该效果。"
+            description.zh-TW: "Willemstad 預設縮小標題前的井號（#）。啟用此項可停用該效果。"
             default: false
     -
             id: remove-collapse-header-sanctum
             title: Disable Sanctum-style Header Collapse Indicator
+            title.zh: "禁用 Sanctum 风格标题折叠指示器"
+            title.zh-TW: "停用 Sanctum 風格標題摺疊指示器"
             type: class-toggle
             description: Sanctum's more minimalist header collapse indicator are used in Willemstad by default. Toggle this to disable this feature and to use the original Obsidian indicator.
+            description.zh: "Willemstad 默认使用 Sanctum 风格的精简标题折叠指示器。启用此项可恢复 Obsidian 原始指示器。"
+            description.zh-TW: "Willemstad 預設使用 Sanctum 風格的精簡標題摺疊指示器。啟用此項可恢復 Obsidian 原始指示器。"
             default: false
     -
         id: typography-h-col-text
         title: Colours — Header Text
+        title.zh: "标题文字颜色"
+        title.zh-TW: "標題文字顏色"
         type: heading
         description: Changes the font colours of the headers (H1–H6).
+        description.zh: "更改 H1-H6 标题的字体颜色。"
+        description.zh-TW: "更改 H1-H6 標題的字型顏色。"
         level: 3
         collapsed: true
     -
     -
             id: gradient-headers
             title: "Gradient Headers"
+            title.zh: "渐变标题"
+            title.zh-TW: "漸變標題"
             type: class-toggle
             description: "When enabled, the headers will have a colour gradient applied to them."
+            description.zh: "启用后，标题采用颜色渐变。"
+            description.zh-TW: "啟用後，標題採用顏色漸變。"
             default: false
     -
             id: col-h1
             title: Font Colour — H1
+            title.zh: "H1 字体颜色"
+            title.zh-TW: "H1 字型顏色"
             type: variable-themed-color
             description:                
             opacity: false
@@ -9887,6 +10179,8 @@ settings:
     -
             id: col-h2
             title: Font Colour — H2
+            title.zh: "H2 字体颜色"
+            title.zh-TW: "H2 字型顏色"
             type: variable-themed-color
             description:                
             opacity: false
@@ -9896,6 +10190,8 @@ settings:
     -
             id: col-h3
             title: Font Colour — H3
+            title.zh: "H3 字体颜色"
+            title.zh-TW: "H3 字型顏色"
             type: variable-themed-color
             description:                
             opacity: false
@@ -9905,6 +10201,8 @@ settings:
     -
             id: col-h4
             title: Font Colour — H4
+            title.zh: "H4 字体颜色"
+            title.zh-TW: "H4 字型顏色"
             type: variable-themed-color
             description:                
             opacity: false
@@ -9914,6 +10212,8 @@ settings:
     -
             id: col-h5
             title: Font Colour — H5
+            title.zh: "H5 字体颜色"
+            title.zh-TW: "H5 字型顏色"
             type: variable-themed-color
             description:                
             opacity: false
@@ -9923,6 +10223,8 @@ settings:
     -
             id: col-h6
             title: Font Colour — H6
+            title.zh: "H6 字体颜色"
+            title.zh-TW: "H6 字型顏色"
             type: variable-themed-color
             description:
             opacity: false
@@ -9932,55 +10234,77 @@ settings:
     -
             id: col-h1-grad
             title: Font Colour (Gradient) — H1
+            title.zh: "H1 渐变字体颜色"
+            title.zh-TW: "H1 漸變字型顏色"
             description:
             type: variable-text
             default: linear-gradient( 160deg, hsl(184deg 75% 20%) 0%, hsl(182deg 100% 19%) 21%, hsl(179deg 100% 21%) 30%, hsl(176deg 100% 23%) 39%, hsl(173deg 100% 26%) 46%, hsl(170deg 100% 28%) 54%, hsl(166deg 100% 30%) 61%, hsl(162deg 100% 33%) 69%, hsl(159deg 100% 35%) 79%, hsl(155deg 100% 37%) 100% )
     -
             id: col-h2-grad
             title: Font Colour (Gradient) — H2
+            title.zh: "H2 渐变字体颜色"
+            title.zh-TW: "H2 漸變字型顏色"
             description:                
             type: variable-text
             default: linear-gradient( 160deg, hsl(155deg 100% 37%) 0%, hsl(164deg 100% 35%) 21%, hsl(175deg 100% 33%) 30%, hsl(187deg 100% 34%) 39%, hsl(197deg 100% 38%) 46%, hsl(204deg 100% 41%) 54%, hsl(210deg 100% 42%) 61%, hsl(214deg 100% 41%) 69%, hsl(219deg 100% 38%) 79%, hsl(238deg 70% 39%) 100% )
     -
             id: col-h3-grad
             title: Font Colour (Gradient) — H3
+            title.zh: "H3 渐变字体颜色"
+            title.zh-TW: "H3 漸變字型顏色"
             description:                
             type: variable-text
             default: linear-gradient( 160deg, hsl(238deg 70% 39%) 0%, hsl(221deg 100% 36%) 21%, hsl(216deg 100% 38%) 30%, hsl(212deg 100% 40%) 39%, hsl(208deg 100% 40%) 46%, hsl(204deg 100% 40%) 54%, hsl(200deg 100% 40%) 61%, hsl(196deg 100% 40%) 69%, hsl(192deg 100% 39%) 79%, hsl(188deg 100% 39%) 100% )
     -
             id: col-h4-grad
             title: Font Colour (Gradient) — H4
+            title.zh: "H4 渐变字体颜色"
+            title.zh-TW: "H4 漸變字型顏色"
             description:                
             type: variable-text
             default: linear-gradient( 160deg, hsl(19deg 100% 57%) 0%, hsl(22deg 100% 56%) 21%, hsl(25deg 100% 56%) 30%, hsl(28deg 100% 55%) 39%, hsl(30deg 100% 55%) 46%, hsl(33deg 100% 54%) 54%, hsl(35deg 100% 54%) 61%, hsl(37deg 100% 54%) 69%, hsl(39deg 100% 54%) 79%, hsl(41deg 100% 55%) 100% )
     -
             id: col-h5-grad
             title: Font Colour (Gradient) — H5
+            title.zh: "H5 渐变字体颜色"
+            title.zh-TW: "H5 漸變字型顏色"
             description:                
             type: variable-text
             default: linear-gradient( 160deg, hsl(41deg 100% 55%) 0%, hsl(34deg 93% 55%) 21%, hsl(27deg 83% 55%) 30%, hsl(19deg 70% 53%) 39%, hsl(11deg 58% 50%) 46%, hsl(2deg 52% 46%) 54%, hsl(352deg 58% 38%) 61%, hsl(343deg 68% 30%) 69%, hsl(334deg 83% 22%) 79%, hsl(326deg 100% 15%) 100% )
     -
             id: col-h6-grad
             title: Font Colour (Gradient) — H6
+            title.zh: "H6 渐变字体颜色"
+            title.zh-TW: "H6 漸變字型顏色"
             description:
             type: variable-text
             default: linear-gradient( 160deg, hsl(324deg 100% 15%) 0%, hsl(330deg 62% 23%) 12%, hsl(334deg 46% 31%) 26%, hsl(337deg 38% 38%) 40%, hsl(340deg 32% 46%) 53%, hsl(343deg 32% 53%) 65%, hsl(345deg 38% 61%) 76%, hsl(348deg 48% 69%) 85%, hsl(350deg 65% 77%) 93%, hsl(352deg 100% 85%) 100% )
     -
         id: typography-h-col-bg
         title: Colours — Header Background
+        title.zh: "标题背景色"
+        title.zh-TW: "標題背景色"
         type: heading
         description: Changes the background colours of the headers (H1–H6).
+        description.zh: "更改 H1-H6 标题的背景色。"
+        description.zh-TW: "更改 H1-H6 標題的背景色。"
         level: 3
         collapsed: true
     -
             id: no-header-bg
             title: Turn off all Header Background Colours
+            title.zh: "关闭全部标题背景色"
+            title.zh-TW: "關閉全部標題背景色"
             type: class-toggle
             description: When enabled, this turns off all header background colours.
+            description.zh: "启用后，关闭所有标题背景色。"
+            description.zh-TW: "啟用後，關閉所有標題背景色。"
             default: false
     -
             id: col-h1-bg
             title: Background Colour — H1
+            title.zh: "H1 背景色"
+            title.zh-TW: "H1 背景色"
             type: variable-themed-color
             description:
             opacity: true
@@ -9990,6 +10314,8 @@ settings:
     -
             id: col-h2-bg
             title: Background Colour — H2
+            title.zh: "H2 背景色"
+            title.zh-TW: "H2 背景色"
             type: variable-themed-color
             description:                
             opacity: true
@@ -9999,6 +10325,8 @@ settings:
     -
             id: col-h3-bg
             title: Background Colour — H3
+            title.zh: "H3 背景色"
+            title.zh-TW: "H3 背景色"
             description:                
             type: variable-themed-color
             opacity: true
@@ -10008,6 +10336,8 @@ settings:
     -
             id: col-h4-bg
             title: Background Colour — H4
+            title.zh: "H4 背景色"
+            title.zh-TW: "H4 背景色"
             type: variable-themed-color
             description:               
             opacity: true
@@ -10017,6 +10347,8 @@ settings:
     -
             id: col-h5-bg
             title: Background Colour — H5
+            title.zh: "H5 背景色"
+            title.zh-TW: "H5 背景色"
             type: variable-themed-color
             description:                
             opacity: true
@@ -10026,6 +10358,8 @@ settings:
     -
             id: col-h6-bg
             title: Background Colour — H6
+            title.zh: "H6 背景色"
+            title.zh-TW: "H6 背景色"
             type: variable-themed-color
             description:                
             opacity: true
@@ -10035,14 +10369,20 @@ settings:
     -
         id: typography-h-size-text
         title: Font Size — Header Text
+        title.zh: "标题文字字号"
+        title.zh-TW: "標題文字字級"
         type: heading
         description: Changes the font size of the headers (H1–H6).
+        description.zh: "更改 H1-H6 标题的字号。"
+        description.zh-TW: "更改 H1-H6 標題的字級。"
         level: 3
         collapsed: true
     -
             id: h1
             find: h1-size
             title: Font Size — H1
+            title.zh: "H1 字号"
+            title.zh-TW: "H1 字級"
             type: variable-number-slider
             default: 1.8
             min: 1
@@ -10053,6 +10393,8 @@ settings:
             id: h2
             find: h2-size
             title: Font Size — H2
+            title.zh: "H2 字号"
+            title.zh-TW: "H2 字級"
             type: variable-number-slider
             default: 1.6
             min: 1
@@ -10063,6 +10405,8 @@ settings:
             id: h3
             find: h3-size
             title: Font Size — H3
+            title.zh: "H3 字号"
+            title.zh-TW: "H3 字級"
             type: variable-number-slider
             default: 1.45
             min: 1
@@ -10073,6 +10417,8 @@ settings:
             id: h4
             find: h4-size
             title: Font Size — H4
+            title.zh: "H4 字号"
+            title.zh-TW: "H4 字級"
             type: variable-number-slider
             default: 1.3
             min: 1
@@ -10083,6 +10429,8 @@ settings:
             id: h5
             find: h5-size
             title: Font Size — H5
+            title.zh: "H5 字号"
+            title.zh-TW: "H5 字級"
             type: variable-number-slider
             default: 1.15
             min: 1
@@ -10093,6 +10441,8 @@ settings:
             id: h6
             find: h6-size
             title: Font Size — H6
+            title.zh: "H6 字号"
+            title.zh-TW: "H6 字級"
             type: variable-number-slider
             default: 1.05
             min: 1
@@ -10102,39 +10452,63 @@ settings:
     -
         id: typography-h-size-paddings
         title: Padding Size — Headers
+        title.zh: "标题内边距"
+        title.zh-TW: "標題內邊距"
         type: heading
         description: Changes the padding size of the headers (H1–H6).
+        description.zh: "更改 H1-H6 标题的内边距。"
+        description.zh-TW: "更改 H1-H6 標題的內邊距。"
         level: 3
         collapsed: true
     -
             id: mirror-header-paddings
             title: Mirror Header Paddings 
+            title.zh: "标题上下内边距保持一致"
+            title.zh-TW: "標題上下內邊距保持一致"
             description: When enabled, this will disable the bottom padding size option, and mirror your top padding size preferences for the bottom padding.
+            description.zh: "启用后，不再单独设置底部内边距，底部沿用顶部内边距。"
+            description.zh-TW: "啟用後，不再單獨設定底部內邊距，底部沿用頂部內邊距。"
             type: class-toggle
             default: false
     -
             id: padding-header-t
             title: Top Padding Size — Headers 
+            title.zh: "标题顶部内边距"
+            title.zh-TW: "標題頂部內邊距"
             description: Accepts any valid CSS units.
+            description.zh: "接受有效的 CSS 单位。"
+            description.zh-TW: "接受有效的 CSS 單位。"
             type: variable-text
             default: 0.125em
     -
             id: padding-header-b
             title: Bottom Padding Size — Headers 
+            title.zh: "标题底部内边距"
+            title.zh-TW: "標題底部內邊距"
             description: Accepts any valid CSS units.
+            description.zh: "接受有效的 CSS 单位。"
+            description.zh-TW: "接受有效的 CSS 單位。"
             type: variable-text
             default: 0.125em
     -
         id: typography-undl
         title: Underlines
+        title.zh: "下划线"
+        title.zh-TW: "底線"
         description: Options to shift underlines lower/increase underline spacing (to increase readability) or to retain it as per default.
+        description.zh: "可将下划线下移、增大与文本的间距以提高可读性，也可保留默认间距。"
+        description.zh-TW: "可將底線下移、增大與文本的間距以提高可讀性，也可保留預設間距。"
         type: heading
         level: 2
         collapsed: true
     -
             id: undl-text-norm
             title: Underlines Spacing — Normal Text
+            title.zh: "下划线间距：普通文本"
+            title.zh-TW: "底線間距：普通文本"
             description: Choose which underline spacing you would like your normal text to have.
+            description.zh: "选择普通文本的下划线间距。"
+            description.zh-TW: "選擇普通文本的底線間距。"
             type: class-select
             allowEmpty: false
             default: llus-nor-max
@@ -10151,7 +10525,11 @@ settings:
     -
             id: undl-hlink
             title: Underlines Spacing — Hyperlinks
+            title.zh: "下划线间距：超链接"
+            title.zh-TW: "底線間距：超連結"
             description: Choose which underline spacing you would like your hyperlinks to have.
+            description.zh: "选择超链接的下划线间距。"
+            description.zh-TW: "選擇超連結的底線間距。"
             type: class-select
             allowEmpty: false
             default: llus-hyp-max
@@ -10168,21 +10546,33 @@ settings:
     -
         id: typography-highlight
         title: Highlights
+        title.zh: "高亮"
+        title.zh-TW: "高亮"
         description: Options to change highlighting colours.
+        description.zh: "调整高亮颜色。"
+        description.zh-TW: "調整高亮顏色。"
         type: heading
         level: 2
         collapsed: true
     -
             id: highlight-col-original
             title: 'Use Standard Highlight Colours'
+            title.zh: "使用标准高亮颜色"
+            title.zh-TW: "使用標準高亮顏色"
             type: class-toggle
             description: When enabled, this will disable the custom Willemstad highlight colours and use the standard colours used for highlighting.
+            description.zh: "启用后，停用 Willemstad 自定义高亮配色，使用标准高亮颜色。"
+            description.zh-TW: "啟用後，停用 Willemstad 自訂高亮配色，使用標準高亮顏色。"
             default: false
     -
             id: col-highlight-text
             title: 'Highlighted Text Colour'
+            title.zh: "高亮文本颜色"
+            title.zh-TW: "高亮文本顏色"
             type: variable-themed-color
             description: 'Colour of the text highlighted — this defaults to black.'
+            description.zh: "高亮区域内的文本颜色，默认为黑色。"
+            description.zh-TW: "高亮區域內的文本顏色，預設為黑色。"
             opacity: false
             format: hsl
             default-light: hsl(0, 0%, 0%)
@@ -10190,8 +10580,12 @@ settings:
     -
             id: col-highlight-0
             title: 'Highlight Colour (Willemstad) — default'
+            title.zh: "Willemstad 默认高亮颜色"
+            title.zh-TW: "Willemstad 預設高亮顏色"
             type: variable-themed-color
             description: 'Default highlight colour (==)'
+            description.zh: "默认高亮颜色（==）。"
+            description.zh-TW: "預設高亮顏色（==）。"
             opacity: false
             format: hsl
             default-light: hsl(46, 100%, 50%)
@@ -10199,8 +10593,12 @@ settings:
     -
             id: col-highlight-1
             title: 'Highlight Colour (Willemstad) — additional #1 (italics + highlight markdown)'
+            title.zh: "Willemstad 附加高亮颜色 #1（斜体与高亮语法）"
+            title.zh-TW: "Willemstad 附加高亮顏色 #1（斜體與高亮語法）"
             type: variable-themed-color
             description: 'Colour of the highlight when you use the italics markdown syntax with the highlight markdown syntax (*==).'
+            description.zh: "同时使用斜体和高亮 Markdown 语法（*==）时的高亮颜色。"
+            description.zh-TW: "同時使用斜體和高亮 Markdown 語法（*==）時的高亮顏色。"
             opacity: false
             format: hsl
             default-light: hsl(76, 100%, 50%)
@@ -10208,7 +10606,11 @@ settings:
     -
             id: col-highlight-2
             title: 'Highlight Colour (Willemstad) — additional #2 (bold + highlight markdown)'
+            title.zh: "Willemstad 附加高亮颜色 #2（粗体与高亮语法）"
+            title.zh-TW: "Willemstad 附加高亮顏色 #2（粗體與高亮語法）"
             description: 'Colour of the highlight when you use the bold markdown syntax with the highlight markdown syntax (**==).'     
+            description.zh: "同时使用粗体和高亮 Markdown 语法（**==）时的高亮颜色。"
+            description.zh-TW: "同時使用粗體和高亮 Markdown 語法（**==）時的高亮顏色。"
             type: variable-themed-color
             opacity: false
             format: hsl
@@ -10217,7 +10619,11 @@ settings:
     -
             id: col-highlight-3
             title: 'Highlight Colour (Willemstad) — additional #3 (bold + italics + highlight markdown)'
+            title.zh: "Willemstad 附加高亮颜色 #3（粗体、斜体与高亮语法）"
+            title.zh-TW: "Willemstad 附加高亮顏色 #3（粗體、斜體與高亮語法）"
             description: 'Colour of the highlight when you use the italics, bold and highlight markdown syntax together (***==).'     
+            description.zh: "同时使用粗体、斜体和高亮 Markdown 语法（***==）时的高亮颜色。"
+            description.zh-TW: "同時使用粗體、斜體和高亮 Markdown 語法（***==）時的高亮顏色。"
             type: variable-themed-color
             opacity: false
             format: hsl
@@ -10226,8 +10632,12 @@ settings:
     -
             id: col-highlight-0-org
             title: 'Highlight Colour (Standard) — default'
+            title.zh: "标准默认高亮颜色"
+            title.zh-TW: "標準預設高亮顏色"
             type: variable-themed-color
             description: 'Default highlight colour (==)'
+            description.zh: "默认高亮颜色（==）。"
+            description.zh-TW: "預設高亮顏色（==）。"
             opacity: false
             format: hsl
             default-light: hsl(60, 100%, 50%)
@@ -10235,8 +10645,12 @@ settings:
     -
             id: col-highlight-1-org
             title: 'Highlight Colour (Standard) — additional #1 (italics + highlight markdown)'
+            title.zh: "标准附加高亮颜色 #1（斜体与高亮语法）"
+            title.zh-TW: "標準附加高亮顏色 #1（斜體與高亮語法）"
             type: variable-themed-color
             description: 'Colour of the highlight when you use the italics markdown syntax with the highlight markdown syntax (*==).'
+            description.zh: "同时使用斜体和高亮 Markdown 语法（*==）时的高亮颜色。"
+            description.zh-TW: "同時使用斜體和高亮 Markdown 語法（*==）時的高亮顏色。"
             opacity: false
             format: hsl
             default-light: hsl(120, 100%, 50%)
@@ -10244,7 +10658,11 @@ settings:
     -
             id: col-highlight-2-org
             title: 'Highlight Colour (Standard) — additional #2 (bold + highlight markdown)'
+            title.zh: "标准附加高亮颜色 #2（粗体与高亮语法）"
+            title.zh-TW: "標準附加高亮顏色 #2（粗體與高亮語法）"
             description: 'Colour of the highlight when you use the bold markdown syntax with the highlight markdown syntax (**==).'     
+            description.zh: "同时使用粗体和高亮 Markdown 语法（**==）时的高亮颜色。"
+            description.zh-TW: "同時使用粗體和高亮 Markdown 語法（**==）時的高亮顏色。"
             type: variable-themed-color
             opacity: false
             format: hsl
@@ -10253,7 +10671,11 @@ settings:
     -
             id: col-highlight-3-org
             title: 'Highlight Colour (Standard) — additional #3 (bold + italics + highlight markdown)'
+            title.zh: "标准附加高亮颜色 #3（粗体、斜体与高亮语法）"
+            title.zh-TW: "標準附加高亮顏色 #3（粗體、斜體與高亮語法）"
             description: 'Colour of the highlight when you use the italics, bold and highlight markdown syntax together (***==).'     
+            description.zh: "同时使用粗体、斜体和高亮 Markdown 语法（***==）时的高亮颜色。"
+            description.zh-TW: "同時使用粗體、斜體和高亮 Markdown 語法（***==）時的高亮顏色。"
             type: variable-themed-color
             opacity: false
             format: hsl
@@ -10262,21 +10684,33 @@ settings:
     -
         id: table-options
         title: Tables
+        title.zh: "表格"
+        title.zh-TW: "表格"
         description: Table-specific options.
+        description.zh: "表格专用选项。"
+        description.zh-TW: "表格專用選項。"
         type: heading
         level: 2
         collapsed: true
     -
             id: table-lp-magic
             title: "Almost-True Rendering"
+            title.zh: "接近阅读效果的渲染"
+            title.zh-TW: "接近閱讀效果的渲染"
             type: class-toggle
             description: "When enabled, this renders Source mode and being-edited Live Preview tables congruently similar to Reading mode and rendered Live Preview tables."
+            description.zh: "启用后，使源码模式和实时预览中正在编辑的表格尽量接近阅读模式与已渲染表格的外观。"
+            description.zh-TW: "啟用後，使原始碼模式和即時預覽中正在編輯的表格儘量接近閱讀模式與已渲染表格的外觀。"
             default: false
     -                   
             id: size-font-editor-table
             title: Font Size — Tables (in Editing mode)
+            title.zh: "表格字号（编辑模式）"
+            title.zh-TW: "表格字級（編輯模式）"
             type: variable-number-slider
             description: Use this setting to change the size of the monospace font when editing tables in Editing mode (both Source mode and Live Preview).
+            description.zh: "设置编辑表格时使用的等宽字体字号，适用于源码模式与实时预览。"
+            description.zh-TW: "設定編輯表格時使用的等寬字型字級，適用於原始碼模式與即時預覽。"
             format: "em"
             default: 0.8
             min: 0.25
@@ -10285,8 +10719,12 @@ settings:
     -
             id: size-font-preview-table-th
             title: Font Size — Table Headers (in Reading mode)
+            title.zh: "表格表头字号（阅读模式）"
+            title.zh-TW: "表格表頭字級（閱讀模式）"
             type: variable-number-slider
             description: Use this setting to change the font size of the table headers in Reading mode.
+            description.zh: "设置阅读模式中的表格表头字号。"
+            description.zh-TW: "設定閱讀模式中的表格表頭字級。"
             format: "em"
             default: 1
             min: 0.25
@@ -10295,8 +10733,12 @@ settings:
     -
             id: size-font-preview-table-td
             title: Font Size — Table Content (in Reading mode)
+            title.zh: "表格内容字号（阅读模式）"
+            title.zh-TW: "表格內容字級（閱讀模式）"
             type: variable-number-slider
             description: Use this setting to change the font size of the table content in Reading mode.
+            description.zh: "设置阅读模式中的表格内容字号。"
+            description.zh-TW: "設定閱讀模式中的表格內容字級。"
             format: "em"
             default: 1
             min: 0.25
@@ -10305,8 +10747,12 @@ settings:
     -
             id: weight-font-preview-table-th
             title: Font Weight — Table Headers (in Reading mode)
+            title.zh: "表格表头字重（阅读模式）"
+            title.zh-TW: "表格表頭字重（閱讀模式）"
             type: variable-number-slider
             description: Use this setting to change the font size of the table content in Reading mode.
+            description.zh: "设置阅读模式中的表格内容字号。"
+            description.zh-TW: "設定閱讀模式中的表格內容字級。"
             format: ''
             default: 800
             min: 100
@@ -10315,8 +10761,12 @@ settings:
     -
             id: weight-font-preview-table-td
             title: Font Weight — Table Content (in Reading mode)
+            title.zh: "表格内容字重（阅读模式）"
+            title.zh-TW: "表格內容字重（閱讀模式）"
             type: variable-number-slider
             description: Use this setting to change the font size of the table content in Reading mode.
+            description.zh: "设置阅读模式中的表格内容字号。"
+            description.zh-TW: "設定閱讀模式中的表格內容字級。"
             format: ''
             default: 400
             min: 100
@@ -10325,8 +10775,12 @@ settings:
     -
             id: col-bg-table
             title: Background Colour — Table Headers
+            title.zh: "表格表头背景色"
+            title.zh-TW: "表格表頭背景色"
             type: variable-themed-color
             description: Change the background colour of the table headers.
+            description.zh: "更改表格表头背景色。"
+            description.zh-TW: "更改表格表頭背景色。"
             opacity: false
             format: hsl
             default-light: hsl(155, 100%, 37%)
@@ -10334,43 +10788,69 @@ settings:
     -
             id: table-alt-bg
             title: Alternate Colours for Tables
+            title.zh: "表格隔行配色"
+            title.zh-TW: "表格隔行配色"
             type: class-toggle
             description: When enabled, the background colours of each successive row (every 2 rows) in the table will be of a different colour.
+            description.zh: "启用后，表格相邻行使用交替背景色，每两行循环一次。"
+            description.zh-TW: "啟用後，表格相鄰行使用交替背景色，每兩行迴圈一次。"
             default: false
     -
             id: table-no-borders-td
             title: No Borders for Table Content
+            title.zh: "表格内容无边框"
+            title.zh-TW: "表格內容無邊框"
             type: class-toggle
             description: "When enabled, the body/content of the tables will not display a border."
+            description.zh: "启用后，表格内容不显示边框。"
+            description.zh-TW: "啟用後，表格內容不顯示邊框。"
             default: false
     -
             id: table-no-borders-th
             title: No Borders for Table Headers
+            title.zh: "表格表头无边框"
+            title.zh-TW: "表格表頭無邊框"
             type: class-toggle
             description: When enabled, the headers of the tables will not display a border.
+            description.zh: "启用后，表格表头不显示边框。"
+            description.zh-TW: "啟用後，表格表頭不顯示邊框。"
             default: false
     -
             id: table-min-space
             title: Space Maximiser (removes all margins/paddings)
+            title.zh: "最大化空间（移除所有内外边距）"
+            title.zh-TW: "最大化空間（移除所有內外邊距）"
             type: class-toggle
             description: When enabled, all margins and paddings of/in the tables will be removed.
+            description.zh: "启用后，移除表格的所有内外边距。"
+            description.zh-TW: "啟用後，移除表格的所有內外邊距。"
             default: false
     -
             id: table-set-minmax
             title: Set Minimum and Maximum Table Widths
+            title.zh: "设置表格最小与最大宽度"
+            title.zh-TW: "設定表格最小與最大寬度"
             type: class-toggle
             description: When enabled, you will gain the ability to set the minimum and maximum widths of your tables.
+            description.zh: "启用后，可设置表格最小宽度与最大宽度。"
+            description.zh-TW: "啟用後，可設定表格最小寬度與最大寬度。"
             default: false
     -
                 id: table-min-space-settings
                 title: "Additional settings available with 'Space Maximiser' option"
+                title.zh: "“最大化空间”启用后的附加设置"
+                title.zh-TW: "“最大化空間”啟用後的附加設定"
                 description: "Too intense? Use the below options to finetune if you need additional spacing."
+                description.zh: "如需保留更多留白，可用下方选项微调间距。"
+                description.zh-TW: "如需保留更多留白，可用下方選項微調間距。"
                 type: heading
                 level: 3
                 collapsed: false
     -
             id: table-td-space-padding-tb
             title: Table Content — Padding — Top and Bottom
+            title.zh: "表格内容上下内边距"
+            title.zh-TW: "表格內容上下內邊距"
             type: variable-number-slider
             format: "px"
             default: 0
@@ -10380,6 +10860,8 @@ settings:
     -
             id: table-td-space-padding-lr
             title: Table Content — Padding — Left and Right
+            title.zh: "表格内容左右内边距"
+            title.zh-TW: "表格內容左右內邊距"
             type: variable-number-slider
             format: "px"
             default: 0
@@ -10389,6 +10871,8 @@ settings:
     -
             id: table-th-space-padding-tb
             title: Table Headers — Padding — Top and Bottom
+            title.zh: "表格表头上下内边距"
+            title.zh-TW: "表格表頭上下內邊距"
             type: variable-number-slider
             format: "px"
             default: 0
@@ -10398,6 +10882,8 @@ settings:
     -
             id: table-th-space-padding-lr
             title: Table Headers — Padding — Left and Right
+            title.zh: "表格表头左右内边距"
+            title.zh-TW: "表格表頭左右內邊距"
             type: variable-number-slider
             format: "px"
             default: 0
@@ -10408,14 +10894,20 @@ settings:
     -
                 id: table-width-settings
                 title: "Additional settings available with 'Set Minimum and Maximum Table Widths' option"
+                title.zh: "“设置表格最小与最大宽度”启用后的附加设置"
+                title.zh-TW: "“設定表格最小與最大寬度”啟用後的附加設定"
                 type: heading
                 level: 3
                 collapsed: true
     -
                 id: width-tables-min
                 title: "Minimum Table Width"
+                title.zh: "表格最小宽度"
+                title.zh-TW: "表格最小寬度"
                 type: variable-number-slider
                 description: "Set the minimum width your tables should be."
+                description.zh: "设置表格最小宽度。"
+                description.zh-TW: "設定表格最小寬度。"
                 format: rem
                 default: 2.5
                 min: 0.5
@@ -10424,8 +10916,12 @@ settings:
     -
                 id: width-tables-max
                 title: "Maximum Table Width"
+                title.zh: "表格最大宽度"
+                title.zh-TW: "表格最大寬度"
                 type: variable-number-slider
                 description: "Set the maximum width your tables should be. "
+                description.zh: "设置表格最大宽度。"
+                description.zh-TW: "設定表格最大寬度。"
                 format: rem
                 default: 25
                 min: 0.5
@@ -10439,21 +10935,33 @@ settings:
     -
      id: callouts-settings
      title: Callouts
+     title.zh: "标注（Callouts）"
+     title.zh-TW: "標註（Callouts）"
      type: heading
      description: "Customise your Callouts here! Special callout classes currently: 'table', 'infobox', 'aside', 'kanban', 'kanban-no-title'"
+     description.zh: "自定义标注。当前特殊标注类包括 table、infobox、aside、kanban 和 kanban-no-title。"
+     description.zh-TW: "自訂標註。當前特殊標註類包括 table、infobox、aside、kanban 和 kanban-no-title。"
      level: 2
      collapsed: false
     -
         id: callout-standard
         title: Standard Obsidian Callouts
+        title.zh: "Obsidian 标准标注"
+        title.zh-TW: "Obsidian 標準標註"
         type: class-toggle
         description: When enabled, the standard Obsidian Callouts styling will be applied instead.
+        description.zh: "启用后，改用 Obsidian 标准标注样式。"
+        description.zh-TW: "啟用後，改用 Obsidian 標準標註樣式。"
         default: false
     -
         id: margin-callout
         title: Callout Margin Size
+        title.zh: "标注外边距"
+        title.zh-TW: "標註外邊距"
         type: variable-number-slider
         description: "Change the size of Callout margins."
+        description.zh: "更改标注外边距。"
+        description.zh-TW: "更改標註外邊距。"
         format: em
         default: 0.5
         min: 0
@@ -10462,16 +10970,24 @@ settings:
     -
         id: kanban-callout
         title: "Kanban Callout"
+        title.zh: "看板标注"
+        title.zh-TW: "看板標註"
         description: "Settings for the 'kanban' callouts."
+        description.zh: "kanban 看板标注设置。"
+        description.zh-TW: "kanban 看板標註設定。"
         type: heading
         level: 3
         collapsed: true
     -
         id: height-callout-kanban
         title: "Callout Height"
+        title.zh: "标注高度"
+        title.zh-TW: "標註高度"
         note: "'Kanban' Callout"
         type: variable-number-slider
         description: "Set the callout height of the Kanban callouts."
+        description.zh: "设置看板标注高度。"
+        description.zh-TW: "設定看板標註高度。"
         format: rem
         default: 30
         min: 8
@@ -10480,9 +10996,13 @@ settings:
     -
         id: height-header-kanban
         title: "Header Height"
+        title.zh: "标题高度"
+        title.zh-TW: "標題高度"
         note: "'Kanban' Callout"
         type: variable-number-slider
         description: "Set the header height of the Kanban callouts."
+        description.zh: "设置看板标注标题高度。"
+        description.zh-TW: "設定看板標註標題高度。"
         format: rem
         default: 3.5
         min: 1
@@ -10491,9 +11011,13 @@ settings:
     -
         id: width-ul-kanban
         title: "Lane Width"
+        title.zh: "看板列宽度"
+        title.zh-TW: "看板列寬度"
         note: "'Kanban' Callout"
         type: variable-number-slider
         description: "Set the kanban lane width of the Kanban callouts."
+        description.zh: "设置看板标注中列的宽度。"
+        description.zh-TW: "設定看板標註中列的寬度。"
         format: px
         default: 272
         min: 80
@@ -10502,9 +11026,13 @@ settings:
     -
         id: size-font-callout-title
         title: "Callout Title Font Size"
+        title.zh: "标注标题字号"
+        title.zh-TW: "標註標題字級"
         note: "'Kanban' Callout"
         type: variable-number-slider
         description: "Set the font size of the Kanban callout title. The default is H1's original size."
+        description.zh: "设置看板标注标题字号。默认为 H1 原始字号。"
+        description.zh-TW: "設定看板標註標題字級。預設為 H1 原始字級。"
         format: em
         default: 1
         min: 0.5
@@ -10513,26 +11041,40 @@ settings:
     -
      id: cssclass-settings
      title: CSSClass
+     title.zh: "CSSClass"
+     title.zh-TW: "CSSClass"
      type: heading
      description: "LaTeX, Magazine, Cornell Notes"
+     description.zh: "LaTeX、杂志与康奈尔笔记。"
+     description.zh-TW: "LaTeX、雜誌與康奈爾筆記。"
      level: 2
      collapsed: false
     -
      id: latex-settings
      title: LaTeX CSSClass
+     title.zh: "LaTeX CSSClass"
+     title.zh-TW: "LaTeX CSSClass"
      description: "Settings for the 'latex' CSSClass."
+     description.zh: "latex CSSClass 设置。"
+     description.zh-TW: "latex CSSClass 設定。"
      type: heading
      level: 3
      collapsed: true
     -
         id: eq-num-latex
         title: "Equation Numbering"
+        title.zh: "公式编号"
+        title.zh-TW: "公式編號"
         type: class-toggle
         description: When enabled, the equations will be numbered incrementally throughout the document.
+        description.zh: "启用后，在整个文档中为公式递增编号。"
+        description.zh-TW: "啟用後，在整個文件中為公式遞增編號。"
         default: false
     -
         id: size-cssclass-latex
         title: "Font Size — LaTeX CSSClass"
+        title.zh: "LaTeX CSSClass 字号"
+        title.zh-TW: "LaTeX CSSClass 字級"
         type: variable-number-slider
         default: 14
         min: 8
@@ -10542,16 +11084,22 @@ settings:
     -
         id: font-cssclass-latex-source
         title: "Font Typeface (Source mode) — LaTeX CSSClass"
+        title.zh: "LaTeX CSSClass 字体（源码模式）"
+        title.zh-TW: "LaTeX CSSClass 字型（原始碼模式）"
         type: variable-text
         default: '"DM Mono" ,"MathJax Main", "MJXZERO", "MJXTEX"'
     -
         id: font-cssclass-latex-reading
         title: "Font Typeface (Reading mode) — LaTeX CSSClass"
+        title.zh: "LaTeX CSSClass 字体（阅读模式）"
+        title.zh-TW: "LaTeX CSSClass 字型（閱讀模式）"
         type: variable-text
         default: '"MathJax Main", "MJXZERO", "MJXTEX"'
     -
         id: textindent-cssclass-latex
         title: "Text Indent for first paragraph line — LaTeX CSSClass"
+        title.zh: "LaTeX CSSClass 段落首行缩进"
+        title.zh-TW: "LaTeX CSSClass 段落首行縮排"
         type: variable-number-slider
         default: 0
         min: -0.5
@@ -10561,8 +11109,12 @@ settings:
     -                   
         id: size-font-editor-table-latex
         title: Font Size — Tables (in Editing mode) for LaTeX CSSClass
+        title.zh: "LaTeX CSSClass 表格字号（编辑模式）"
+        title.zh-TW: "LaTeX CSSClass 表格字級（編輯模式）"
         type: variable-number-slider
         description: Use this setting to change the size of the monospace font when editing tables in Editing mode (both Source mode and Live Preview) for the LaTeX CSSClass.
+        description.zh: "设置 LaTeX CSSClass 下编辑表格时的等宽字体字号，适用于源码模式与实时预览。"
+        description.zh-TW: "設定 LaTeX CSSClass 下編輯表格時的等寬字型字級，適用於原始碼模式與即時預覽。"
         format: "em"
         default: 0.8
         min: 0.25
@@ -10571,8 +11123,12 @@ settings:
     -
         id: size-font-preview-table-latex
         title: Font Size — Tables (in Reading mode) for LaTeX CSSClass
+        title.zh: "LaTeX CSSClass 表格字号（阅读模式）"
+        title.zh-TW: "LaTeX CSSClass 表格字級（閱讀模式）"
         type: variable-number-slider
         description: Use this setting to change the font size of the tables in Reading mode for the LaTeX CSSClass.
+        description.zh: "设置 LaTeX CSSClass 下阅读模式中的表格字号。"
+        description.zh-TW: "設定 LaTeX CSSClass 下閱讀模式中的表格字級。"
         format: "em"
         default: 1
         min: 0.25
@@ -10581,18 +11137,28 @@ settings:
     -
      id: magazine-settings
      title: Magazine CSSClass
+     title.zh: "杂志 CSSClass"
+     title.zh-TW: "雜誌 CSSClass"
      description: "Settings for the 'magazine' CSSClass."
+     description.zh: "magazine 杂志 CSSClass 设置。"
+     description.zh-TW: "magazine 雜誌 CSSClass 設定。"
      type: heading
      level: 3
      collapsed: true
     -
         id: magazine-cssclass-see-syntax
         title: "See an example of how to make your own Magazine"
+        title.zh: "查看自建杂志的示例"
+        title.zh-TW: "檢視自建雜誌的示例"
         description: https://willemstad.cc/Examples/CSSClass-Magazine
+        description.zh: "https://willemstad.cc/Examples/CSSClass-Magazine"
+        description.zh-TW: "https://willemstad.cc/Examples/CSSClass-Magazine"
         type: class-toggle
     -
         id: size-cssclass-magazine
         title: "Font Size — Magazine CSSClass"
+        title.zh: "杂志 CSSClass 字号"
+        title.zh-TW: "雜誌 CSSClass 字級"
         type: variable-number-slider
         default: 1.5
         min: 0.75
@@ -10602,12 +11168,16 @@ settings:
     -
         id: font-cssclass-magazine
         title: "Font Typeface — Magazine CSSClass"
+        title.zh: "杂志 CSSClass 字体"
+        title.zh-TW: "雜誌 CSSClass 字型"
         type: variable-text
         default: '"Manrope" ,"DM Sans", "Inter"'
         note: do I change var(--font-ui) in the thing
     -
         id: weight-cssclass-magazine
         title: "Font Weight — Magazine CSSClass"
+        title.zh: "杂志 CSSClass 字重"
+        title.zh-TW: "雜誌 CSSClass 字重"
         type: variable-number-slider
         default: 500
         min: 100
@@ -10617,8 +11187,12 @@ settings:
     -
         id: height-items-magazine
         title: "Card Height — Magazine CSSClass"
+        title.zh: "杂志 CSSClass 卡片高度"
+        title.zh-TW: "雜誌 CSSClass 卡片高度"
         type: variable-number-slider
         description: "Use this setting to change height of the magazine cards."
+        description.zh: "设置杂志卡片高度。"
+        description.zh-TW: "設定雜誌卡片高度。"
         default: 10
         min: 3
         max: 50
@@ -10627,8 +11201,12 @@ settings:
     -
         id: margin-items-magazine
         title: "Inter-Cards Margin — Magazine CSSClass"
+        title.zh: "杂志 CSSClass 卡片间距"
+        title.zh-TW: "雜誌 CSSClass 卡片間距"
         type: variable-number-slider
         description: "Use this setting to change the external spacing (margins) between magazine cards."
+        description.zh: "设置杂志卡片之间的外边距。"
+        description.zh-TW: "設定雜誌卡片之間的外邊距。"
         default: 0.25
         min: 0
         max: 1.5
@@ -10637,8 +11215,12 @@ settings:
     -
         id: padding-items-magazine
         title: "Card Padding — Magazine CSSClass"
+        title.zh: "杂志 CSSClass 卡片内边距"
+        title.zh-TW: "雜誌 CSSClass 卡片內邊距"
         type: variable-number-slider
         description: "Use this setting to change the internal spacing between the card content and card borders"
+        description.zh: "设置卡片内容与边框之间的内边距。"
+        description.zh-TW: "設定卡片內容與邊框之間的內邊距。"
         default: 0.75
         min: 0
         max: 3
@@ -10647,32 +11229,52 @@ settings:
     -
         id: bg-highlight-magazine-first
         title: "Background (First item) — Magazine CSSClass"
+        title.zh: "杂志 CSSClass 背景（首个项目）"
+        title.zh-TW: "雜誌 CSSClass 背景（首個專案）"
         description: "Use this to customise the background to the 1st item."
+        description.zh: "自定义第一个项目的背景。"
+        description.zh-TW: "自訂第一個專案的背景。"
         type: variable-text
         default: 'linear-gradient(45deg, hsl(240, 100%, 20%) 0%, hsl(289, 100%, 21%) 11%, hsl(315, 100%, 27%) 22%, hsl(329, 100%, 36%) 33%, hsl(337, 100%, 43%) 44%, hsl(357, 91%, 59%) 56%, hsl(17, 100%, 59%) 67%, hsl(34, 100%, 53%) 78%, hsl(45, 100%, 50%) 89%, hsl(55, 100%, 50%) 100%)'
     -
         id: bg-highlight-magazine
         title: "Background (Wide items) — Magazine CSSClass"
+        title.zh: "杂志 CSSClass 背景（宽版项目）"
+        title.zh-TW: "雜誌 CSSClass 背景（寬版專案）"
         description: "Use this to customise the background to every 9n+1 item."
+        description.zh: "自定义每个序号为 9n+1 的项目的背景。"
+        description.zh-TW: "自訂每個序號為 9n+1 的專案的背景。"
         type: variable-text
         default: 'linear-gradient(to right, hsl(215, 65%, 53%), hsl(191, 100%, 50%))'
     -
      id: cornell-settings
      title: Cornell Notes CSSClass
+     title.zh: "康奈尔笔记 CSSClass"
+     title.zh-TW: "康奈爾筆記 CSSClass"
      description: "Settings for the 'cornell' CSSClass."
+     description.zh: "cornell 康奈尔笔记 CSSClass 设置。"
+     description.zh-TW: "cornell 康奈爾筆記 CSSClass 設定。"
      type: heading
      level: 3
      collapsed: true
     -
         id: cornell-cssclass-see-syntax
         title: "See an example of how to make your own Cornell Notes"
+        title.zh: "查看自建康奈尔笔记的示例"
+        title.zh-TW: "檢視自建康奈爾筆記的示例"
         description: https://willemstad.cc/Examples/CSSClass-Cornell
+        description.zh: "https://willemstad.cc/Examples/CSSClass-Cornell"
+        description.zh-TW: "https://willemstad.cc/Examples/CSSClass-Cornell"
         type: class-toggle
     -
         id: left-align-cornell-cssclass
         title: "Left Margin — Cornell Notes CSSClass"
+        title.zh: "康奈尔笔记 CSSClass 左侧外边距"
+        title.zh-TW: "康奈爾筆記 CSSClass 左側外邊距"
         type: variable-number-slider
         description: "Use this setting to change the left margin of the Cornell Notes CSSClass."
+        description.zh: "设置康奈尔笔记 CSSClass 的左侧外边距。"
+        description.zh-TW: "設定康奈爾筆記 CSSClass 的左側外邊距。"
         default: 30
         min: 10
         max: 50
@@ -10681,8 +11283,12 @@ settings:
     -
         id: gap-cornell-cssclass
         title: "Gap Between Left and Right Content — Cornell Notes CSSClass"
+        title.zh: "康奈尔笔记 CSSClass 左右内容间距"
+        title.zh-TW: "康奈爾筆記 CSSClass 左右內容間距"
         type: variable-number-slider
         description: "Use this setting to change the gap between the left and right content of the Cornell Notes CSSClass."
+        description.zh: "设置康奈尔笔记 CSSClass 左右内容之间的间距。"
+        description.zh-TW: "設定康奈爾筆記 CSSClass 左右內容之間的間距。"
         default: 2.5
         min: 0
         max: 10
@@ -10691,6 +11297,10 @@ settings:
     -
         id: text-align-cornell-cssclass
         title: "Text Alignment — Cornell Notes CSSClass"
+        title.zh: "康奈尔笔记 CSSClass 文本对齐方式"
+        title.zh-TW: "康奈爾筆記 CSSClass 文本對齊方式"
+        description.zh: "选项含义：Justify：两端对齐；Left：左；Right：右；Centre：居中。"
+        description.zh-TW: "選項含義：Justify：兩端對齊；Left：左；Right：右；Centre：居中。"
         type: variable-select
         default: justify
         options:
@@ -10709,6 +11319,10 @@ settings:
     -
         id: text-align-last-cornell-cssclass
         title: "Text Alignment (Last Line) — Cornell Notes CSSClass"
+        title.zh: "康奈尔笔记 CSSClass 末行文本对齐方式"
+        title.zh-TW: "康奈爾筆記 CSSClass 末行文本對齊方式"
+        description.zh: "选项含义：Justify：两端对齐；Left：左；Right：右；Centre：居中。"
+        description.zh-TW: "選項含義：Justify：兩端對齊；Left：左；Right：右；Centre：居中。"
         type: variable-select
         default: right
         options:
@@ -10727,40 +11341,64 @@ settings:
     -
      id: html-settings
      title: HTML Styling
+     title.zh: "HTML 样式"
+     title.zh-TW: "HTML 樣式"
      type: heading
      description: "LaTeX, Magazine, Cornell Notes"
+     description.zh: "LaTeX、杂志与康奈尔笔记。"
+     description.zh-TW: "LaTeX、雜誌與康奈爾筆記。"
      level: 2
      collapsed: false
     -
         id: progressbar-settings
         title: Progress Bar
+        title.zh: "进度条"
+        title.zh-TW: "進度條"
         type: heading
         description: "Settings for the Progress Bar"
+        description.zh: "进度条设置。"
+        description.zh-TW: "進度條設定。"
         level: 3
         collapsed: true
     -
             id: percentage-progressbar
             title: "Append Percentage to Progress Bar"
+            title.zh: "在进度条末尾显示百分比"
+            title.zh-TW: "在進度條末尾顯示百分比"
             type: class-toggle
             description: "When enabled, this will append the progress bar percentage to the right end of the progress bar."
+            description.zh: "启用后，在进度条右端显示百分比。"
+            description.zh-TW: "啟用後，在進度條右端顯示百分比。"
             default: false 
     -
      id: misc
      title: "Miscellany"
+     title.zh: "其他设置"
+     title.zh-TW: "其他設定"
      type: heading
      description: Centre Image; Image Desaturation; Fix Widths for MathJax equations, Mermaid.js graphs and images; Rounded Headers and Boxes; Hide External Hyperlink URLs in Source Mode
+     description.zh: "图片居中、图片去色、MathJax 公式宽度修复、Mermaid.js 图表宽度修复、图片宽度修复、圆角标题与框，以及源码模式下隐藏外部链接 URL。"
+     description.zh-TW: "圖片居中、圖片去色、MathJax 公式寬度修復、Mermaid.js 圖表寬度修復、圖片寬度修復、圓角標題與框，以及原始碼模式下隱藏外部連結 URL。"
      level: 2
      collapsed: false
     -
             id: centre-image
             title: Centre Image
+            title.zh: "图片居中"
+            title.zh-TW: "圖片居中"
             type: class-toggle
             description: When enabled, this centres embedded images in your notes.
+            description.zh: "启用后，笔记中的嵌入图片居中显示。"
+            description.zh-TW: "啟用後，筆記中的嵌入圖片居中顯示。"
             default: true
     -
             id: image-desaturation
             title: Image Desaturation
+            title.zh: "图片去色"
+            title.zh-TW: "圖片去色"
             description: Choose which images should be desaturated when not hovered.
+            description.zh: "选择哪些图片在未悬停时去色。 选项含义：None：无；Reading mode：阅读模式；Reading mode + Live Preview：阅读模式与实时预览。"
+            description.zh-TW: "選擇哪些圖片在未懸停時去色。 選項含義：None：無；Reading mode：閱讀模式；Reading mode + Live Preview：閱讀模式與即時預覽。"
             type: class-select
             allowEmpty: false
             default: default
@@ -10777,32 +11415,52 @@ settings:
     -
             id: fix-mathjax-width
             title: Fix MathJax Equation Width
+            title.zh: "修复 MathJax 公式宽度"
+            title.zh-TW: "修復 MathJax 公式寬度"
             type: class-toggle
             description: When enabled, this fixes the MathJax equation width to fit the viewpane.
+            description.zh: "启用后，修复 MathJax 公式宽度以适应面板。"
+            description.zh-TW: "啟用後，修復 MathJax 公式寬度以適應面板。"
             default: false
     -
             id: fix-mermaid-width
             title: Fix Mermaid.js Graph Width
+            title.zh: "修复 Mermaid.js 图表宽度"
+            title.zh-TW: "修復 Mermaid.js 圖表寬度"
             type: class-toggle
             description: When enabled, this fixes the Mermaid.js graph width to fit the viewpane.
+            description.zh: "启用后，修复 Mermaid.js 图表宽度以适应面板。"
+            description.zh-TW: "啟用後，修復 Mermaid.js 圖表寬度以適應面板。"
             default: true
     -
             id: fix-img-width
             title: Fix Image Width
+            title.zh: "修复图片宽度"
+            title.zh-TW: "修復圖片寬度"
             type: class-toggle
             description: When enabled, this fixes the image width to fit the viewpane.
+            description.zh: "启用后，修复图片宽度以适应面板。"
+            description.zh-TW: "啟用後，修復圖片寬度以適應面板。"
             default: true
     -
             id: headers-round
             title: Rounded Headers and Boxes
+            title.zh: "标题与框使用圆角"
+            title.zh-TW: "標題與框使用圓角"
             type: class-toggle
             description: When enabled, rounded-border headers and boxes (such as Admonition and Callout boxes) will be applied over the standard rectangular ones.
+            description.zh: "启用后，标题与框（如 Admonition 和标注）使用圆角，而非标准直角。"
+            description.zh-TW: "啟用後，標題與框（如 Admonition 和標註）使用圓角，而非標準直角。"
             default: false
     -
             id: source-links-hide
             title: Shimmering Focus-style Hide External Hyperlink URLs in Source Mode
+            title.zh: "在源码模式隐藏外部链接 URL（Shimmering Focus 风格）"
+            title.zh-TW: "在原始碼模式隱藏外部連結 URL（Shimmering Focus 風格）"
             type: class-toggle
             description: When enabled, this hides external hyperlink URLs in Source mode, similar to Shimmering Focus.
+            description.zh: "启用后，在源码模式隐藏外部链接 URL，效果类似 Shimmering Focus。"
+            description.zh-TW: "啟用後，在原始碼模式隱藏外部連結 URL，效果類似 Shimmering Focus。"
             default: false
     -
 */
@@ -10851,13 +11509,19 @@ settings:
     -
      id: plugin-core
      title: Core Plugins
+     title.zh: "核心插件"
+     title.zh-TW: "核心外掛"
      type: heading
      description: "Command Palette"
+     description.zh: "命令面板。"
+     description.zh-TW: "命令面板。"
      level: 2
      collapsed: false
     -
      id: PCore001-settings
      title: Command Palette
+     title.zh: "命令面板"
+     title.zh-TW: "命令面板"
      description: 
      type: heading
      level: 3
@@ -10865,20 +11529,30 @@ settings:
     -
             id: normal-command-palette
             title: Revert back to standard Obsidian style
+            title.zh: "恢复 Obsidian 标准样式"
+            title.zh-TW: "恢復 Obsidian 標準樣式"
             note: Command Palette
             type: class-toggle
             description: When enabled, this moves the plugin name back to the left. Use when the Command Palette looks wonky.
+            description.zh: "启用后，将插件名称移回左侧。命令面板显示异常时可尝试此项。"
+            description.zh-TW: "啟用後，將外掛名稱移回左側。命令面板顯示異常時可嘗試此項。"
             default: false
     -
      id: plugin-community
      title: Community Plugins
+     title.zh: "社区插件"
+     title.zh-TW: "社群外掛"
      type: heading
      description: "Admonitions, Calendar, Footnotes & Citation Indicator, Full Calendar, Kanban, Sliding Panes, Style Settings, Longform"
+     description.zh: "Admonitions、Calendar、Footnotes & Citation Indicator、Full Calendar、Kanban、Sliding Panes、Style Settings 和 Longform。"
+     description.zh-TW: "Admonitions、Calendar、Footnotes & Citation Indicator、Full Calendar、Kanban、Sliding Panes、Style Settings 和 Longform。"
      level: 2
      collapsed: false
     -
      id: PComm003-settings
      title: Admonitions
+     title.zh: "Admonitions"
+     title.zh-TW: "Admonitions"
      description: 
      type: heading
      level: 3
@@ -10886,6 +11560,8 @@ settings:
     -
         id: PComm003-margin
         title: Change the size of the margins
+        title.zh: "更改外边距"
+        title.zh-TW: "更改外邊距"
         note: Admonitions
         type: variable-number-slider
         format: px
@@ -10896,9 +11572,13 @@ settings:
     -
         id: admonition-margin-top
         title: Change size of padding
+        title.zh: "更改内边距"
+        title.zh-TW: "更改內邊距"
         note: Admonitions
         type: variable-number-slider
         description: "Admonition's original settings are 1.625."
+        description.zh: "Admonition 原始值为 1.625。"
+        description.zh-TW: "Admonition 原始值為 1.625。"
         format: em
         default: 0.5
         min: 0
@@ -10907,6 +11587,8 @@ settings:
     -
      id: PComm001-settings
      title: Calendar
+     title.zh: "Calendar"
+     title.zh-TW: "Calendar"
      description: 
      type: heading
      level: 3
@@ -10914,9 +11596,13 @@ settings:
     -
         id: PComm001-col-today
         title: Change colour, Font of today's date
+        title.zh: "更改今日日期字体颜色"
+        title.zh-TW: "更改今日日期字型顏色"
         note: 📆 Calendar
         type: variable-themed-color
         description: Change the font colour for today's date in the Calendar plugin.
+        description.zh: "更改 Calendar 插件中今日日期的字体颜色。"
+        description.zh-TW: "更改 Calendar 外掛中今日日期的字型顏色。"
         opacity: false
         format: hsl
         default-light: hsl(155, 100%, 37%)
@@ -10924,9 +11610,13 @@ settings:
     -
         id: PComm001-col-year
         title: Change colour, Font of the year
+        title.zh: "更改年份字体颜色"
+        title.zh-TW: "更改年份字型顏色"
         note: 📆 Calendar
         type: variable-themed-color
         description: Change the font colour for the year in the Calendar plugin.
+        description.zh: "更改 Calendar 插件中年份的字体颜色。"
+        description.zh-TW: "更改 Calendar 外掛中年份的字型顏色。"
         opacity: false
         format: hsl
         default-light: hsl(155, 100%, 37%)
@@ -10934,9 +11624,13 @@ settings:
     -
         id: PComm001-col-dot
         title: Change colour, Filled dot
+        title.zh: "更改实心圆点颜色"
+        title.zh-TW: "更改實心圓點顏色"
         note: 📆 Calendar
         type: variable-themed-color
         description: Change the colour of the dot in the Calendar plugin.
+        description.zh: "更改 Calendar 插件中圆点的颜色。"
+        description.zh-TW: "更改 Calendar 外掛中圓點的顏色。"
         opacity: false
         format: hsl
         default-light: hsl(155, 100%, 37%)
@@ -10944,6 +11638,8 @@ settings:
     -
      id: PComm033-settings
      title: Focus Mode
+     title.zh: "Focus Mode"
+     title.zh-TW: "Focus Mode"
      description: 
      type: heading
      level: 3
@@ -10951,21 +11647,31 @@ settings:
     -
         id: PComm033-standard-focus
         title: Disable True Focus Mode
+        title.zh: "禁用完全专注模式"
+        title.zh-TW: "停用完全專注模式"
         note: Focus Mode
         type: class-toggle
         description: "By default, Willemstad removes the exit button in Focus Mode. This toggle re-enables the ribbon and its accompanying exit button."
+        description.zh: "Willemstad 默认移除 Focus Mode 的退出按钮。启用此项可恢复侧边工具栏及其退出按钮。"
+        description.zh-TW: "Willemstad 預設移除 Focus Mode 的退出按鈕。啟用此項可恢復側邊工具列及其退出按鈕。"
         default: false
     -
         id: PComm033-transparent-header
         title: Make Un-Hovered Title Headers Transparent in Focus Mode
+        title.zh: "专注模式下标题栏在未悬停时透明"
+        title.zh-TW: "專注模式下標題列在未懸停時透明"
         note: Focus Mode
         type: class-toggle
         description: "When enabled, this toggle makes title headers transparent when un-hovered. Hover over for title headers to reappear."
+        description.zh: "启用后，标题栏在未悬停时透明，鼠标悬停后重新显示。"
+        description.zh-TW: "啟用後，標題列在未懸停時透明，滑鼠懸停後重新顯示。"
         default: false
     -
     -
      id: PComm027-settings
      title: Footnotes & Citation Indicator
+     title.zh: "Footnotes & Citation Indicator"
+     title.zh-TW: "Footnotes & Citation Indicator"
      description: 
      type: heading
      level: 3
@@ -10973,20 +11679,30 @@ settings:
     -
         id: PComm027-active
         title: Activate Footnotes and Citation Indicator and Relevant Settings
+        title.zh: "启用脚注与引用指示器及相关设置"
+        title.zh-TW: "啟用腳註與引用指示器及相關設定"
         note: 🦶📝 Footnotes & Citation Indicator
         type: class-toggle
         description: "Toggle to make Style Settings changes to the Footnotes and Citation Indicator. When enabled, this can also be used independently of the plugin."
+        description.zh: "启用后，可通过 Style Settings 调整 Footnotes and Citation Indicator。此功能也可独立于该插件使用。"
+        description.zh-TW: "啟用後，可通過 Style Settings 調整 Footnotes and Citation Indicator。此功能也可獨立於該外掛使用。"
         default: false
     -
         id: PComm027-indicator
         title: Change Gutter Indicator
+        title.zh: "更改编辑器边栏指示器"
+        title.zh-TW: "更改編輯器邊欄指示器"
         note: 🦶📝 Footnotes & Citation Indicator
         type: variable-text
         description: "Change the gutter indicator icon here, for the Footnotes & Citation Indicator plugin."
+        description.zh: "更改 Footnotes & Citation Indicator 插件的编辑器边栏指示图标。"
+        description.zh-TW: "更改 Footnotes & Citation Indicator 外掛的編輯器邊欄指示圖示。"
         default: '⦿'
     -
      id: PComm009-settings
      title: Full Calendar
+     title.zh: "Full Calendar"
+     title.zh-TW: "Full Calendar"
      description: 
      type: heading
      level: 3
@@ -10994,13 +11710,19 @@ settings:
     -
         id: PComm009-no-halfhour-grid
         title: Remove Half-hour Dotted Lines
+        title.zh: "移除半小时虚线"
+        title.zh-TW: "移除半小時虛線"
         note: 💯📆 Full Calendar
         type: class-toggle
         description: "When enabled, this removes the half-hour dotted lines from the Full Calendar calendar view."
+        description.zh: "启用后，移除 Full Calendar 日历视图中的半小时虚线。"
+        description.zh-TW: "啟用後，移除 Full Calendar 日曆檢視中的半小時虛線。"
         default: false
     -
      id: PComm007-settings
      title: Kanban
+     title.zh: "Kanban"
+     title.zh-TW: "Kanban"
      description: 
      type: heading
      level: 3
@@ -11008,23 +11730,35 @@ settings:
     -
         id: PComm007-sp-singlelane
         title: Vertical Scroll Kanbans in Side Panes
+        title.zh: "侧边面板看板纵向滚动"
+        title.zh-TW: "側邊面板看板縱向滾動"
         note: Kanban
         type: class-toggle
         description: When enabled, multiple kanban lanes in the side panes can be navigated via scrolling vertically rather than scrolling horizontally.
+        description.zh: "启用后，侧边面板中的多列看板采用纵向滚动，而非横向滚动。"
+        description.zh-TW: "啟用後，側邊面板中的多列看板採用縱向滾動，而非橫向滾動。"
         default: false
     -
         id: PComm007-sp-fitwidth
         title: Fit to Width of Side Panes
+        title.zh: "适应侧边面板宽度"
+        title.zh-TW: "適應側邊面板寬度"
         note: Kanban
         type: class-toggle
         description: When enabled, the kanban lanes in the side panes will fit to the width of the side panes.
+        description.zh: "启用后，看板列适应侧边面板宽度。"
+        description.zh-TW: "啟用後，看板列適應側邊面板寬度。"
         default: false
     -
         id: PComm007-sp-maxheight
         title: Max Height of Vertical Kanban Lane in Side Panes
+        title.zh: "侧边面板纵向看板列最大高度"
+        title.zh-TW: "側邊面板縱向看板列最大高度"
         note: Kanban
         type: variable-number-slider
         description: "Set the maximum height of each kanban lane in the side panes, when vertical."
+        description.zh: "设置侧边面板采用纵向布局时，每个看板列的最大高度。"
+        description.zh-TW: "設定側邊面板採用縱向佈局時，每個看板列的最大高度。"
         default: 33
         min: 5
         max: 100
@@ -11033,23 +11767,35 @@ settings:
     -
         id: PComm007-wp-singlelane
         title: Vertical Scroll Kanbans in Main Workspace Panes
+        title.zh: "主工作区面板看板纵向滚动"
+        title.zh-TW: "主工作區面板看板縱向滾動"
         note: Kanban
         type: class-toggle
         description: When enabled, multiple kanban lanes in the main workspace panes can be navigated via scrolling vertically rather than scrolling horizontally.
+        description.zh: "启用后，主工作区面板中的多列看板采用纵向滚动，而非横向滚动。"
+        description.zh-TW: "啟用後，主工作區面板中的多列看板採用縱向滾動，而非橫向滾動。"
         default: false
     -
         id: PComm007-wp-fitwidth
         title: Fit to Width of Main Workspace Panes
+        title.zh: "适应主工作区面板宽度"
+        title.zh-TW: "適應主工作區面板寬度"
         note: Kanban
         type: class-toggle
         description: When enabled, the kanban lanes in the main workspace panes will fit to the width of the pane.
+        description.zh: "启用后，看板列适应主工作区面板宽度。"
+        description.zh-TW: "啟用後，看板列適應主工作區面板寬度。"
         default: false
     -
         id: PComm007-wp-maxheight
         title: Max Height of Vertical Kanban Lane in Main Workspace Panes
+        title.zh: "主工作区面板纵向看板列最大高度"
+        title.zh-TW: "主工作區面板縱向看板列最大高度"
         note: Kanban
         type: variable-number-slider
         description: "Set the maximum height of each kanban lane in the main workspace panes, when vertical."
+        description.zh: "设置主工作区面板采用纵向布局时，每个看板列的最大高度。"
+        description.zh-TW: "設定主工作區面板採用縱向佈局時，每個看板列的最大高度。"
         default: 33
         min: 5
         max: 100
@@ -11058,6 +11804,8 @@ settings:
     -
      id: PComm002-settings
      title: Sliding Panes
+     title.zh: "Sliding Panes"
+     title.zh-TW: "Sliding Panes"
      description: 
      type: heading
      level: 3
@@ -11065,20 +11813,30 @@ settings:
     -
         id: PComm002-shadow
         title: Re-enable Shadows between Two Panes
+        title.zh: "重新启用两个面板之间的阴影"
+        title.zh-TW: "重新啟用兩個面板之間的陰影"
         note: Sliding Panes
         type: class-toggle
         description: "By default, Willemstad removes Sliding Panes' shadows. This toggle re-enables the shadows between two sliding panes when using the Sliding Panes plugin."
+        description.zh: "Willemstad 默认移除 Sliding Panes 的阴影。启用此项可恢复使用该插件时两个滑动面板之间的阴影。"
+        description.zh-TW: "Willemstad 預設移除 Sliding Panes 的陰影。啟用此項可恢復使用該外掛時兩個滑動面板之間的陰影。"
         default: false
     -
         id: PComm002-rotate-title
         title: Rotate Document Title
+        title.zh: "旋转文档标题"
+        title.zh-TW: "旋轉文件標題"
         note: Sliding Panes
         type: class-toggle
         description: "When enabled, the document title will rotate 180 degrees when using the Sliding Panes plugin. This is useful for right-aligned document titles. Title alignments can be changed in the Editor settings."
+        description.zh: "启用后，使用 Sliding Panes 时文档标题旋转 180 度，适合右对齐的文档标题。标题对齐方式可在编辑器设置中调整。"
+        description.zh-TW: "啟用後，使用 Sliding Panes 時文件標題旋轉 180 度，適合右對齊的文件標題。標題對齊方式可在編輯器設定中調整。"
         default: false
     -
      id: PComm000-settings
      title: Style Settings
+     title.zh: "Style Settings"
+     title.zh-TW: "Style Settings"
      description: 
      type: heading
      level: 3
@@ -11086,13 +11844,19 @@ settings:
     -
         id: PComm000-blockdesc-appear
         title: Keep Header Block Description visible
+        title.zh: "保持标题区块说明可见"
+        title.zh-TW: "保持標題區塊說明可見"
         note: ⚙️ Style Settings
         type: class-toggle
         description: When enabled, this keeps the header description in the Style Settings visible when said option is toggled.
+        description.zh: "启用后，在折叠相关选项时，Style Settings 的标题说明仍保持可见。"
+        description.zh-TW: "啟用後，在摺疊相關選項時，Style Settings 的標題說明仍保持可見。"
         default: true
     -
      id: longform-settings
      title: Longform plugin & Writing CSSClass
+     title.zh: "Longform 插件与写作 CSSClass"
+     title.zh-TW: "Longform 外掛與寫作 CSSClass"
      description: 
      type: heading
      level: 3
@@ -11100,13 +11864,19 @@ settings:
     -    
         id: font-longform
         title: Font Typeface — Longform & Writing notes
+        title.zh: "Longform 与写作笔记字体"
+        title.zh-TW: "Longform 與寫作筆記字型"
         description: "Globally overrides all font typefaces for specific use with longform & writing notes, except for code, which still uses the monospace font."
+        description.zh: "覆盖 Longform 和写作笔记的全部字体，但代码仍使用等宽字体。"
+        description.zh-TW: "覆蓋 Longform 和寫作筆記的全部字型，但程式碼仍使用等寬字型。"
         note: ✍️📕 Longform plugin & Writing CSSClass
         type: variable-text
         default: '"Crimson Pro"'
     -
         id: size-font-longform
         title: Font Size — Longform & Writing notes
+        title.zh: "Longform 与写作笔记字号"
+        title.zh-TW: "Longform 與寫作筆記字級"
         note: ✍️📕 Longform plugin & Writing CSSClass
         type: variable-number-slider
         default: 1.2
@@ -11117,42 +11887,66 @@ settings:
     -
         id: PComm029-text-indent
         title: Text Indentation — Longform & Writing notes
+        title.zh: "Longform 与写作笔记文本缩进"
+        title.zh-TW: "Longform 與寫作筆記文本縮排"
         note: ✍️📕 Longform plugin & Writing CSSClass
         type: class-toggle
         description: When enabled, longform & writing notes will be indented.
+        description.zh: "启用后，Longform 和写作笔记的文本采用缩进。"
+        description.zh-TW: "啟用後，Longform 和寫作筆記的文本採用縮排。"
         default: false
     -
         id: PComm029-justify
         title: Text Justification — Longform & Writing notes
+        title.zh: "Longform 与写作笔记文本两端对齐"
+        title.zh-TW: "Longform 與寫作筆記文本兩端對齊"
         note: ✍️📕 Longform plugin & Writing CSSClass
         type: class-toggle
         description: When enabled, longform & writing notes will be justified.
+        description.zh: "启用后，Longform 和写作笔记的文本采用两端对齐。"
+        description.zh-TW: "啟用後，Longform 和寫作筆記的文本採用兩端對齊。"
         default: false
     -
         id: support-willemstad
         title: Support the development of Willemstad
+        title.zh: "支持 Willemstad 的开发"
+        title.zh-TW: "支援 Willemstad 的開發"
         type: heading
         level: 2
         description: 'Hi! I hope you enjoy Willemstad. There are a few ways you can support its continuing development:'
+        description.zh: "希望你喜欢 Willemstad。可通过以下方式支持主题的持续开发："
+        description.zh-TW: "希望你喜歡 Willemstad。可通過以下方式支援主題的持續開發："
         collapsed: false
     -
         id: support-willemstad-github
         title: Star the repository on Github!
+        title.zh: "在 GitHub 为代码仓库加星！"
+        title.zh-TW: "在 GitHub 為程式碼倉庫加星！"
         type: class-toggle
         default: false
         description: https://github.com/tingmelvin/willemstad-x
+        description.zh: "https://github.com/tingmelvin/willemstad-x"
+        description.zh-TW: "https://github.com/tingmelvin/willemstad-x"
     -
         id: support-willemstad-issue
         title: Submit an issue or a feature request on Github!
+        title.zh: "在 GitHub 提交问题或功能请求！"
+        title.zh-TW: "在 GitHub 提交問題或功能請求！"
         type: class-toggle
         default: false    
         description: https://github.com/tingmelvin/willemstad-x/issues
+        description.zh: "https://github.com/tingmelvin/willemstad-x/issues"
+        description.zh-TW: "https://github.com/tingmelvin/willemstad-x/issues"
     -
         id: support-willemstad-obsidian
         title: Purchase a Catalyst license with Obsidian!
+        title.zh: "购买 Obsidian Catalyst 许可！"
+        title.zh-TW: "購買 Obsidian Catalyst 許可！"
         type: class-toggle
         default: false
         description: https://obsidian.md/pricing
+        description.zh: "https://obsidian.md/pricing"
+        description.zh-TW: "https://obsidian.md/pricing"
 */
 /* ────────────────────────────────────────────────────────────────────────────────
 > WX000
@@ -15987,41 +16781,61 @@ settings:
     -
         id: img-grid
         title: Toggle Image Grid Globally
+        title.zh: "全局启用图片网格"
+        title.zh-TW: "全域啟用圖片網格"
         description: "When enabled, this toggles the Image Grid extension from Minimal, by @kepano, globally. If you would like to use Image Grid for specific notes, you can alternatively use 'img-grid' as a CSSClass for your relevant notes."
+        description.zh: "启用后，全局应用 @kepano 为 Minimal 制作的图片网格扩展。如只需用于特定笔记，可为笔记设置 img-grid CSSClass。"
+        description.zh-TW: "啟用後，全域應用 @kepano 為 Minimal 製作的圖片網格擴充套件。如只需用於特定筆記，可為筆記設定 img-grid CSSClass。"
         type: class-toggle
     -
         id: cards-min-width
         title: Minimum Card Width
+        title.zh: "卡片最小宽度"
+        title.zh-TW: "卡片最小寬度"
         description: Accepts any valid CSS units.
+        description.zh: "接受有效的 CSS 单位。"
+        description.zh-TW: "接受有效的 CSS 單位。"
         type: variable-text
         default: 180px
     - 
         id: cards-max-width
         title: Maximum Card Width
+        title.zh: "卡片最大宽度"
+        title.zh-TW: "卡片最大寬度"
         description: Accepts any valid CSS units, default fills the available width.
+        description.zh: "接受有效的 CSS 单位，默认填满可用宽度。"
+        description.zh-TW: "接受有效的 CSS 單位，預設填滿可用寬度。"
         type: variable-text
         default: 1fr
     - 
         id: cards-padding
         title: Card Padding
+        title.zh: "卡片内边距"
+        title.zh-TW: "卡片內邊距"
         description: 
         type: variable-text
         default: 1.2em
     - 
         id: cards-image-height
         title: Maximum Card Image Height
+        title.zh: "卡片图片最大高度"
+        title.zh-TW: "卡片圖片最大高度"
         description: 
         type: variable-text
         default: 400px
     - 
         id: cards-border-width
         title: Card Border Width
+        title.zh: "卡片边框宽度"
+        title.zh-TW: "卡片邊框寬度"
         description: 
         type: variable-text
         default: 1px
     -  
         id: cards-background
         title: Card Background Colour
+        title.zh: "卡片背景色"
+        title.zh-TW: "卡片背景色"
         type: variable-themed-color
         format: hsl
         default-light: 'hsla(0, 0%, 0%, 0)'
@@ -16029,7 +16843,11 @@ settings:
     -
         id: support-kepano
         title: "Minimal Cards is created by @kepano! Please support him at his Buy Me a Coffee site if you've liked it!"
+        title.zh: "Minimal Cards 由 @kepano 创作。喜欢此功能可在 Buy Me a Coffee 支持他！"
+        title.zh-TW: "Minimal Cards 由 @kepano 創作。喜歡此功能可在 Buy Me a Coffee 支援他！"
         description: https://www.buymeacoffee.com/kepano
+        description.zh: "https://www.buymeacoffee.com/kepano"
+        description.zh-TW: "https://www.buymeacoffee.com/kepano"
         type: class-toggle
         default: false
 */
@@ -16053,26 +16871,38 @@ settings:
     -
         id: readme-adv-settings
         title: I declare I am absolutely sure of what I am doing, and I want to access Advanced Settings.
+        title.zh: "我确定了解这些设置的作用，并希望访问高级设置。"
+        title.zh-TW: "我確定瞭解這些設定的作用，並希望訪問進階設定。"
         type: class-toggle
         description: 
         default: false
     -
      id: adv-settings-frontmatter
      title: "Advanced Settings — Frontmatter"
+     title.zh: "高级设置：Frontmatter"
+     title.zh-TW: "進階設定：Frontmatter"
      type: heading
      level: 2
      collapsed: false
     -
         id: adv-settings-frontmatter-colour
         title: "Coloured YAML Options"
+        title.zh: "彩色 YAML 选项"
+        title.zh-TW: "彩色 YAML 選項"
         description: "The advanced options here are only available and displayed when the Coloured YAML option is checked."
+        description.zh: "仅在启用彩色 YAML 时，才显示并允许使用这些高级选项。"
+        description.zh-TW: "僅在啟用彩色 YAML 時，才顯示並允許使用這些進階選項。"
         type: heading
         level: 3
         collapsed: false
     -
             id: col-frontmatter-default
             title: col-frontmatter-default
+            title.zh: "Frontmatter 默认颜色（col-frontmatter-default）"
+            title.zh-TW: "Frontmatter 預設顏色（col-frontmatter-default）"
             description: "Default Frontmatter Colour. Typically controlled via text-accent-hover's colour."
+            description.zh: "Frontmatter 默认颜色，通常由 text-accent-hover 的颜色控制。"
+            description.zh-TW: "Frontmatter 預設顏色，通常由 text-accent-hover 的顏色控制。"
             type: variable-themed-color
             opacity: false
             format: hsl
@@ -16081,7 +16911,11 @@ settings:
     -
             id: col-frontmatter-atom
             title: col-frontmatter-atom
+            title.zh: "Frontmatter 原子值颜色（col-frontmatter-atom）"
+            title.zh-TW: "Frontmatter 原子值顏色（col-frontmatter-atom）"
             description: "Atom Frontmatter Colour. Typically controlled via text-accent's colour."
+            description.zh: "Frontmatter 原子值颜色，通常由 text-accent 的颜色控制。"
+            description.zh-TW: "Frontmatter 原子值顏色，通常由 text-accent 的顏色控制。"
             type: variable-themed-color
             opacity: false
             format: hsl
@@ -16090,7 +16924,11 @@ settings:
     -
             id: col-frontmatter-meta
             title: col-frontmatter-meta
+            title.zh: "Frontmatter 元数据颜色（col-frontmatter-meta）"
+            title.zh-TW: "Frontmatter 後設資料顏色（col-frontmatter-meta）"
             description: "Meta Frontmatter Colour. Typically controlled via text-accent-hover's colour."
+            description.zh: "Frontmatter 元数据颜色，通常由 text-accent-hover 的颜色控制。"
+            description.zh-TW: "Frontmatter 後設資料顏色，通常由 text-accent-hover 的顏色控制。"
             type: variable-themed-color
             opacity: false
             format: hsl
@@ -16099,7 +16937,11 @@ settings:
     -
             id: col-frontmatter-number
             title: col-frontmatter-number
+            title.zh: "Frontmatter 数字颜色（col-frontmatter-number）"
+            title.zh-TW: "Frontmatter 數字顏色（col-frontmatter-number）"
             description: "Number Frontmatter Colour. Typically controlled via text-accent-hover's colour."
+            description.zh: "Frontmatter 数字颜色，通常由 text-accent-hover 的颜色控制。"
+            description.zh-TW: "Frontmatter 數字顏色，通常由 text-accent-hover 的顏色控制。"
             type: variable-themed-color
             opacity: false
             format: hsl
@@ -16108,53 +16950,79 @@ settings:
     -
      id: adv-settings-smolfont
      title: "Advanced Settings — Small Fonts"
+     title.zh: "高级设置：小字号"
+     title.zh-TW: "進階設定：小字級"
      type: heading
      level: 2
      collapsed: true
     -
         id: size-font-searchbox
         title: size-font-searchbox
+        title.zh: "搜索框字号（size-font-searchbox）"
+        title.zh-TW: "搜尋框字級（size-font-searchbox）"
         description: "General size controls for all small items. Accepts any valid CSS units"
+        description.zh: "统一控制各类小型元素的字号。接受有效的 CSS 单位。"
+        description.zh-TW: "統一控制各類小型元素的字級。接受有效的 CSS 單位。"
         type: variable-text
         default: 0.9em
     -
         id: size-font-input
         title: size-font-input
+        title.zh: "输入框字号（size-font-input）"
+        title.zh-TW: "輸入框字級（size-font-input）"
         type: variable-text
         default: 'var(--size-font-searchbox)'
     -
         id: size-font-dropdown
         title: size-font-dropdown
+        title.zh: "下拉菜单字号（size-font-dropdown）"
+        title.zh-TW: "下拉選單字級（size-font-dropdown）"
         type: variable-text
         default: 'var(--size-font-searchbox)'        
     -
         id: size-font-select
         title: size-font-select
+        title.zh: "选择控件字号（size-font-select）"
+        title.zh-TW: "選擇控制元件字級（size-font-select）"
         type: variable-text
         default: 'var(--size-font-searchbox)'
     -
         id: size-font-mod-settings-navitem
         title: size-font-mod-settings-navitem
+        title.zh: "设置导航项字号（size-font-mod-settings-navitem）"
+        title.zh-TW: "設定導航項字級（size-font-mod-settings-navitem）"
         description: 'Font size for Settings modal navigation items.' 
+        description.zh: "设置对话框导航项的字号。"
+        description.zh-TW: "設定對話方塊導航項的字級。"
         type: variable-text
         default: 'calc(var(--size-font-searchbox) * 1.1)'        
     -
         id: size-font-mod-settings-grptitle
         title: size-font-mod-settings-grptitle
+        title.zh: "设置分组标题字号（size-font-mod-settings-grptitle）"
+        title.zh-TW: "設定分組標題字級（size-font-mod-settings-grptitle）"
         description: 'Font size for Settings modal header titles ("Options" and "Plugin Options").' 
+        description.zh: "设置对话框分组标题（“选项”和“插件选项”）的字号。"
+        description.zh-TW: "設定對話方塊分組標題（“選項”和“外掛選項”）的字級。"
         type: variable-text
         default: 'var(--size-font-searchbox)'        
     -
     -
      id: adv-settings-col
      title: "Advanced Settings — Colours"
+     title.zh: "高级设置：颜色"
+     title.zh-TW: "進階設定：顏色"
      type: heading
      description: "Ever wanted to change every single element's colour? Here's your chance to do so!"
+     description.zh: "在此逐项自定义各个元素的颜色。"
+     description.zh-TW: "在此逐項自訂各個元素的顏色。"
      level: 2
      collapsed: false
     -
      id: adv-settings-col-bg
      title: "Background"
+     title.zh: "背景"
+     title.zh-TW: "背景"
      type: heading
      description:
      level: 3
@@ -16162,6 +17030,8 @@ settings:
     -
             id: background-primary
             title: background-primary
+            title.zh: "主背景（background-primary）"
+            title.zh-TW: "主背景（background-primary）"
             type: variable-themed-color
             opacity: false
             format: hsl
@@ -16170,6 +17040,8 @@ settings:
     -
             id: background-primary-alt
             title: background-primary-alt
+            title.zh: "主背景变体（background-primary-alt）"
+            title.zh-TW: "主背景變體（background-primary-alt）"
             type: variable-themed-color
             opacity: false
             format: hsl
@@ -16178,6 +17050,8 @@ settings:
     -
             id: background-secondary
             title: background-secondary
+            title.zh: "次背景（background-secondary）"
+            title.zh-TW: "次背景（background-secondary）"
             type: variable-themed-color
             opacity: false
             format: hsl
@@ -16186,6 +17060,8 @@ settings:
     -
             id: background-secondary-alt
             title: background-secondary-alt
+            title.zh: "次背景变体（background-secondary-alt）"
+            title.zh-TW: "次背景變體（background-secondary-alt）"
             type: variable-themed-color
             opacity: false
             format: hsl
@@ -16194,8 +17070,12 @@ settings:
     -
             id: background-primary-contra
             title: background-primary-contra
+            title.zh: "主背景对比色（background-primary-contra）"
+            title.zh-TW: "主背景對比色（background-primary-contra）"
             type: variable-themed-color
             description: 'Applies only for Nord palette.'
+            description.zh: "仅适用于 Nord 配色方案。"
+            description.zh-TW: "僅適用於 Nord 配色方案。"
             opacity: false
             format: hsl
             default-light: hsl(220, 16%, 22%)
@@ -16203,6 +17083,8 @@ settings:
     -
             id: background-modifier-border
             title: background-modifier-border
+            title.zh: "边框颜色（background-modifier-border）"
+            title.zh-TW: "邊框顏色（background-modifier-border）"
             type: variable-themed-color
             opacity: false
             format: hsl
@@ -16211,6 +17093,8 @@ settings:
     -
             id: background-modifier-form-field
             title: background-modifier-form-field
+            title.zh: "表单字段背景（background-modifier-form-field）"
+            title.zh-TW: "表單欄位背景（background-modifier-form-field）"
             type: variable-themed-color
             opacity: true
             format: hsl
@@ -16219,6 +17103,8 @@ settings:
     -
             id: background-modifier-form-field-highlighted
             title: background-modifier-form-field-highlighted
+            title.zh: "高亮表单字段背景（background-modifier-form-field-highlighted）"
+            title.zh-TW: "高亮表單欄位背景（background-modifier-form-field-highlighted）"
             type: variable-themed-color
             opacity: true
             format: hsl
@@ -16227,6 +17113,8 @@ settings:
     -
             id: background-modifier-box-shadow
             title: background-modifier-box-shadow
+            title.zh: "盒阴影颜色（background-modifier-box-shadow）"
+            title.zh-TW: "盒陰影顏色（background-modifier-box-shadow）"
             type: variable-themed-color
             opacity: true
             format: hsl
@@ -16235,6 +17123,8 @@ settings:
     -
             id: background-modifier-success
             title: background-modifier-success
+            title.zh: "成功提示背景（background-modifier-success）"
+            title.zh-TW: "成功提示背景（background-modifier-success）"
             type: variable-themed-color
             opacity: false
             format: hsl
@@ -16243,6 +17133,8 @@ settings:
     -
             id: background-modifier-error
             title: background-modifier-error
+            title.zh: "错误提示背景（background-modifier-error）"
+            title.zh-TW: "錯誤提示背景（background-modifier-error）"
             type: variable-themed-color
             opacity: false
             format: hsl
@@ -16251,6 +17143,8 @@ settings:
     -
             id: background-modifier-error-hover
             title: background-modifier-error-hover
+            title.zh: "错误提示悬停背景（background-modifier-error-hover）"
+            title.zh-TW: "錯誤提示懸停背景（background-modifier-error-hover）"
             type: variable-themed-color
             opacity: false
             format: hsl
@@ -16259,6 +17153,8 @@ settings:
     -
             id: background-modifier-cover
             title: background-modifier-cover
+            title.zh: "遮罩背景（background-modifier-cover）"
+            title.zh-TW: "遮罩背景（background-modifier-cover）"
             type: variable-themed-color
             opacity: true
             format: hsl
@@ -16267,6 +17163,8 @@ settings:
     -
      id: adv-settings-col-text
      title: "Text"
+     title.zh: "文本"
+     title.zh-TW: "文本"
      type: heading
      description:
      level: 3
@@ -16274,6 +17172,8 @@ settings:
     -
             id: text-accent
             title: text-accent
+            title.zh: "文本强调色（text-accent）"
+            title.zh-TW: "文本強調色（text-accent）"
             type: variable-themed-color
             opacity: false
             format: hsl
@@ -16282,6 +17182,8 @@ settings:
     -
             id: text-accent-hover
             title: text-accent-hover
+            title.zh: "文本悬停强调色（text-accent-hover）"
+            title.zh-TW: "文本懸停強調色（text-accent-hover）"
             type: variable-themed-color
             opacity: false
             format: hsl
@@ -16290,6 +17192,8 @@ settings:
     -
             id: text-normal
             title: text-normal
+            title.zh: "普通文本（text-normal）"
+            title.zh-TW: "普通文本（text-normal）"
             type: variable-themed-color
             opacity: false
             format: hsl
@@ -16298,6 +17202,8 @@ settings:
     -
             id: text-muted
             title: text-muted
+            title.zh: "弱化文本（text-muted）"
+            title.zh-TW: "弱化文本（text-muted）"
             type: variable-themed-color
             opacity: false
             format: hsl
@@ -16306,6 +17212,8 @@ settings:
     -
             id: text-faint
             title: text-faint
+            title.zh: "淡色文本（text-faint）"
+            title.zh-TW: "淡色文本（text-faint）"
             type: variable-themed-color
             opacity: false
             format: hsl
@@ -16314,6 +17222,8 @@ settings:
     -
             id: text-error
             title: text-error
+            title.zh: "错误文本（text-error）"
+            title.zh-TW: "錯誤文本（text-error）"
             type: variable-themed-color
             opacity: false
             format: hsl
@@ -16322,6 +17232,8 @@ settings:
     -
             id: text-error-hover
             title: text-error-hover
+            title.zh: "错误文本悬停色（text-error-hover）"
+            title.zh-TW: "錯誤文本懸停色（text-error-hover）"
             type: variable-themed-color
             opacity: false
             format: hsl
@@ -16330,6 +17242,8 @@ settings:
     -
             id: text-selection
             title: text-selection
+            title.zh: "文本选区（text-selection）"
+            title.zh-TW: "文本選區（text-selection）"
             type: variable-themed-color
             opacity: true
             format: hsl
@@ -16338,6 +17252,8 @@ settings:
     -
             id: text-on-accent
             title: text-on-accent
+            title.zh: "强调色背景上的文本（text-on-accent）"
+            title.zh-TW: "強調色背景上的文本（text-on-accent）"
             type: variable-themed-color
             opacity: false
             format: hsl
@@ -16346,6 +17262,8 @@ settings:
     -
      id: adv-settings-col-interactive
      title: "Interactives"
+     title.zh: "交互元素"
+     title.zh-TW: "互動元素"
      type: heading
      description:
      level: 3
@@ -16353,6 +17271,8 @@ settings:
     -
             id: interactive-bg
             title: interactive-bg
+            title.zh: "交互背景（interactive-bg）"
+            title.zh-TW: "互動背景（interactive-bg）"
             type: variable-themed-color
             opacity: false
             format: hsl
@@ -16361,6 +17281,8 @@ settings:
     -
             id: interactive-border-color
             title: interactive-border-color
+            title.zh: "交互边框（interactive-border-color）"
+            title.zh-TW: "互動邊框（interactive-border-color）"
             type: variable-themed-color
             opacity: false
             format: hsl
@@ -16369,6 +17291,8 @@ settings:
     -
             id: interactive-normal
             title: interactive-normal
+            title.zh: "交互元素常态（interactive-normal）"
+            title.zh-TW: "互動元素常態（interactive-normal）"
             type: variable-themed-color
             opacity: false
             format: hsl
@@ -16377,6 +17301,8 @@ settings:
     -
             id: interactive-hover
             title: interactive-hover
+            title.zh: "交互元素悬停态（interactive-hover）"
+            title.zh-TW: "互動元素懸停態（interactive-hover）"
             type: variable-themed-color
             opacity: false
             format: hsl
@@ -16385,6 +17311,8 @@ settings:
     -
             id: interactive-accent
             title: interactive-accent
+            title.zh: "交互强调色（interactive-accent）"
+            title.zh-TW: "互動強調色（interactive-accent）"
             type: variable-themed-color
             opacity: false
             format: hsl
@@ -16393,6 +17321,8 @@ settings:
     -
             id: interactive-accent-hover
             title: interactive-accent-hover
+            title.zh: "交互悬停强调色（interactive-accent-hover）"
+            title.zh-TW: "互動懸停強調色（interactive-accent-hover）"
             type: variable-themed-color
             opacity: false
             format: hsl
@@ -16401,6 +17331,8 @@ settings:
     -
             id: interactive-success
             title: interactive-success
+            title.zh: "交互成功色（interactive-success）"
+            title.zh-TW: "互動成功色（interactive-success）"
             type: variable-themed-color
             opacity: false
             format: hsl
@@ -16409,6 +17341,8 @@ settings:
     -
      id: adv-settings-col-others
      title: "Others"
+     title.zh: "其他"
+     title.zh-TW: "其他"
      type: heading
      description:
      level: 3
@@ -16416,6 +17350,8 @@ settings:
     -
             id: scrollbar-active-thumb-bg
             title: scrollbar-active-thumb-bg
+            title.zh: "活动滚动条滑块背景（scrollbar-active-thumb-bg）"
+            title.zh-TW: "活動捲軸滑塊背景（scrollbar-active-thumb-bg）"
             type: variable-themed-color
             opacity: true
             format: hsl
@@ -16424,6 +17360,8 @@ settings:
     -
             id: scrollbar-bg
             title: scrollbar-bg
+            title.zh: "滚动条背景（scrollbar-bg）"
+            title.zh-TW: "捲軸背景（scrollbar-bg）"
             type: variable-themed-color
             opacity: true
             format: hsl
@@ -16432,6 +17370,8 @@ settings:
     -
             id: scrollbar-thumb-bg
             title: scrollbar-thumb-bg
+            title.zh: "滚动条滑块背景（scrollbar-thumb-bg）"
+            title.zh-TW: "捲軸滑塊背景（scrollbar-thumb-bg）"
             type: variable-themed-color
             opacity: true
             format: hsl
@@ -16440,6 +17380,8 @@ settings:
     -
             id: scroll-hover
             title: scroll-hover
+            title.zh: "滚动条悬停色（scroll-hover）"
+            title.zh-TW: "捲軸懸停色（scroll-hover）"
             type: variable-themed-color
             opacity: false
             format: hsl
@@ -16448,6 +17390,8 @@ settings:
     -
             id: col-selection
             title: col-selection
+            title.zh: "选区颜色（col-selection）"
+            title.zh-TW: "選區顏色（col-selection）"
             type: variable-themed-color
             opacity: false
             format: hsl

--- a/theme.css
+++ b/theme.css
@@ -41337,26 +41337,42 @@ settings:
     -
         id: info-theme-documentation
         title: Theme Documentation
+        title.zh: "主题文档"
+        title.zh-TW: "主題文件"
         type: info-text
         description: "[Website](https://willemstad.cc)"
+        description.zh: "[网站](https://willemstad.cc)"
+        description.zh-TW: "[網站](https://willemstad.cc)"
         markdown: true
     -
         id: info-theme-repository
         title: Theme Repository
+        title.zh: "主题代码仓库"
+        title.zh-TW: "主題程式碼倉庫"
         type: info-text
         description: "[GitHub](https://github.com/tingmelvin/willemstad-x)"
+        description.zh: "[GitHub](https://github.com/tingmelvin/willemstad-x)"
+        description.zh-TW: "[GitHub](https://github.com/tingmelvin/willemstad-x)"
         markdown: true
     -
         id: info-theme-mobile-support
         title: Mobile Support
+        title.zh: "移动端支持"
+        title.zh-TW: "行動版支援"
         type: class-toggle
         description: "Please note that Willemstad is not optimised for mobile devices at the moment."
+        description.zh: "Willemstad 目前尚未针对移动设备优化。"
+        description.zh-TW: "Willemstad 目前尚未針對行動裝置最佳化。"
         default: false
     -
         id: info-theme-macos-support
         title: macOS and iOS Support
+        title.zh: "macOS 和 iOS 支持"
+        title.zh-TW: "macOS 和 iOS 支援"
         type: class-toggle
         description: "Please note that the maintainer of Willemstad does not have access to either a Mac and/or an iOS device, which have slightly different styling in the core Obsidian app. Therefore, the theme has not been ensured to work properly with macOS and iOS. Bug reports are however very welcome to resolve these issues."
+        description.zh: "Willemstad 的维护者没有可用的 Mac 或 iOS 设备，而这些平台的 Obsidian 基础样式略有不同，因此尚不能保证主题在 macOS 和 iOS 上正常显示。欢迎提交问题报告以协助修复。"
+        description.zh-TW: "Willemstad 的維護者沒有可用的 Mac 或 iOS 裝置，而這些平臺的 Obsidian 基礎樣式略有不同，因此尚不能保證主題在 macOS 和 iOS 上正常顯示。歡迎提交問題報告以協助修復。"
         default: false
 */
 
@@ -41367,46 +41383,70 @@ settings:
     -
         id: no-animations
         title: No Animations
+        title.zh: "禁用动画"
+        title.zh-TW: "停用動畫"
         type: class-toggle
         document: AC01-Opt-Animations
         description: "When enabled, this disables all animations in this theme."
+        description.zh: "启用后，禁用本主题的所有动画。"
+        description.zh-TW: "啟用後，停用本主題的所有動畫。"
         default: false
     -
         id: no-blur
         title: No Blur Backdrop Filter
+        title.zh: "禁用背景模糊滤镜"
+        title.zh-TW: "停用背景模糊濾鏡"
         type: class-toggle
         document: AC02-Opt-BackdropFilter
         description: "The blur filter is activated by default in Willemstad, and might cause slight performance degradation on less powerful devices. When enabled, this disables all blur backdrop filters set by this theme."
+        description.zh: "Willemstad 默认启用背景模糊滤镜，在性能较低的设备上可能略微影响性能。启用此项后，禁用本主题设置的所有背景模糊滤镜。"
+        description.zh-TW: "Willemstad 預設啟用背景模糊濾鏡，在效能較低的裝置上可能略微影響效能。啟用此項後，停用本主題設定的所有背景模糊濾鏡。"
         default: false
     -
         id: yes-shadows
         title: Re-enable Shadows
+        title.zh: "重新启用阴影"
+        title.zh-TW: "重新啟用陰影"
         type: class-toggle
         document: AC03-Opt-Shadows
         description: "Willemstad removes all shadows in Obsidian by default. When enabled, this enables all shadows disabled by this theme."
+        description.zh: "Willemstad 默认移除 Obsidian 中的全部阴影。启用后，恢复被本主题禁用的阴影。"
+        description.zh-TW: "Willemstad 預設移除 Obsidian 中的全部陰影。啟用後，恢復被本主題停用的陰影。"
         default: false
     -
         id: ssopt-hidden-scrollbars
         title: Hide Scrollbars
+        title.zh: "隐藏滚动条"
+        title.zh-TW: "隱藏捲軸"
         type: class-toggle
         document: AJ04-Scrollbars
         notes: (For Windows and Linux only)
         description: "When enabled, Obsidian’s non-native scrollbars in Windows and Linux are replaced with zero-width tracks, giving the interface a neater look."
+        description.zh: "启用后，将 Windows 和 Linux 中 Obsidian 的非原生滚动条轨道设为零宽度，使界面更简洁。"
+        description.zh-TW: "啟用後，將 Windows 和 Linux 中 Obsidian 的非原生捲軸軌道設為零寬度，使介面更簡潔。"
         default: false
         addCommand: true
     -
         id: ssopt-hide-tooltips
         title: Hide Tooltips
+        title.zh: "隐藏工具提示"
+        title.zh-TW: "隱藏工具提示"
         type: class-toggle
         description: "When enabled, this hides all tooltips that appear when hovering over buttons and other UI elements."
+        description.zh: "启用后，隐藏鼠标悬停在按钮等界面元素上时出现的工具提示。"
+        description.zh-TW: "啟用後，隱藏滑鼠懸停在按鈕等介面元素上時出現的工具提示。"
         default: false
         addCommand: true
     -
         id: shape-roundish
         title: "Border Radius"
+        title.zh: "圆角半径"
+        title.zh-TW: "圓角半徑"
         type: variable-number-slider
         document: AB11-Set-Radius
         description: "This setting controls the border radius of all elements in this theme, and/or are calculated from this value. The default value is 6px."
+        description.zh: "控制本主题各元素的圆角半径，部分元素的圆角也由此值计算得出。默认为 6px。"
+        description.zh-TW: "控制本主題各元素的圓角半徑，部分元素的圓角也由此值計算得出。預設為 6px。"
         format: "px"
         min: 0
         max: 10
@@ -41415,14 +41455,22 @@ settings:
     -
         id: radius-image
         title: 'Border Radius of Images'
+        title.zh: "图片圆角半径"
+        title.zh-TW: "圖片圓角半徑"
         type: variable-text
         description: "Controls the default border radius for images throughout the theme. Accepts any valid CSS radius value (e.g., 8px, 0, var(--radius-m)). Set '0' if you do not want your images to take a border radius."
+        description.zh: "控制主题中图片的默认圆角半径。接受有效的 CSS 圆角值，例如 8px、0 或 var(--radius-m)。设为 0 可取消图片圆角。"
+        description.zh-TW: "控制主題中圖片的預設圓角半徑。接受有效的 CSS 圓角值，例如 8px、0 或 var(--radius-m)。設為 0 可取消圖片圓角。"
         default: 'var(--radius-s)'
     -
         id: divider-width
         title: Divider Width
+        title.zh: "分隔线宽度"
+        title.zh-TW: "分隔線寬度"
         type: variable-number-slider
         description: "Controls the thickness of divider lines throughout the theme."
+        description.zh: "控制主题中分隔线的粗细。"
+        description.zh-TW: "控制主題中分隔線的粗細。"
         format: "px"
         min: 0
         max: 5
@@ -41437,89 +41485,127 @@ settings:
     -
         id: info-global-typography-split
         title: Note on Global Typography
+        title.zh: "全局排版说明"
+        title.zh-TW: "全域排版說明"
         type: info-text
         description: "This section controls global typography settings like font sizes, underlines, bold, and italic styles, which affects every element within Obsidian. For settings specific to the editor, such as Markdown headers and Canvas typography options, please see the **Editor** section."
+        description.zh: "此区域控制全局字号、下划线、粗体和斜体等排版，影响 Obsidian 中的所有元素。Markdown 标题、白板等编辑器专用排版设置请见 **Editor** 区域。"
+        description.zh-TW: "此區域控制全域字級、底線、粗體和斜體等排版，影響 Obsidian 中的所有元素。Markdown 標題、白板等編輯器專用排版設定請見 **Editor** 區域。"
         markdown: true
     -
         id: typography-typeface
         title: Typeface
+        title.zh: "字体"
+        title.zh-TW: "字型"
         type: heading
         description: "Typeface options for Willemstad. For CSSClass settings, please use their specific options in the specific CSSClass settings panel. Font settings set in core Obsidian (Appearance > Font) will override the settings set here."
+        description.zh: "Willemstad 字体选项。CSSClass 的字体请在对应 CSSClass 设置面板调整。Obsidian 的“外观 > 字体”设置会覆盖此处的设置。"
+        description.zh-TW: "Willemstad 字型選項。CSSClass 的字型請在對應 CSSClass 設定面板調整。Obsidian 的“外觀 > 字型”設定會覆蓋此處的設定。"
         level: 2
         collapsed: false
     -
             id: font-monospace-theme
             title: Font Typeface — Monospace
+            title.zh: "字体：等宽"
+            title.zh-TW: "字型：等寬"
             type: variable-text
             document: AB02-Set-Typography
             default: '"DM Mono"'
     -
             id: font-heading
             title: Font Typeface — Headers
+            title.zh: "字体：标题"
+            title.zh-TW: "字型：標題"
             type: variable-text
             document: AB02-Set-Typography
             default: '"Manrope", "Inter 4.1", "DM Sans"'
     -
             id: font-editor
             title: Font Typeface — Editor
+            title.zh: "字体：编辑器"
+            title.zh-TW: "字型：編輯器"
             type: variable-text
             document: AB02-Set-Typography
             default: '"Inter 4.1", "DM Sans", "Manrope"'
     -
             id: font-menu
             title: Font Typeface — Menu
+            title.zh: "字体：菜单"
+            title.zh-TW: "字型：選單"
             type: variable-text
             document: AB02-Set-Typography
             default: '"Manrope", "Inter 4.1", "DM Sans"'
     -
             id: font-ui
             title: Font Typeface — User Interface (UI)
+            title.zh: "字体：用户界面"
+            title.zh-TW: "字型：使用者介面"
             type: variable-text
             document: AB02-Set-Typography
             default: '"Manrope", "Inter 4.1", "DM Sans"'
     -
             id: font-editor-m
             title: Font Typeface — Mobile Editor
+            title.zh: "字体：移动端编辑器"
+            title.zh-TW: "字型：行動版編輯器"
             type: variable-text
             document: AB02-Set-Typography
             default: '"Inter 4.1", "DM Sans", "Manrope"'
     -
             id: font-menu-m
             title: Font Typeface — Mobile Menu
+            title.zh: "字体：移动端菜单"
+            title.zh-TW: "字型：行動版選單"
             type: variable-text
             document: AB02-Set-Typography
             default: '"Manrope", "Inter 4.1", "DM Sans"'
     -
             id: font-ui-m
             title: Font Typeface — Mobile User Interface (UI)
+            title.zh: "字体：移动端用户界面"
+            title.zh-TW: "字型：行動版使用者介面"
             type: variable-text
             document: AB02-Set-Typography
             default: '"Manrope", "Inter 4.1", "DM Sans"'
     -
             id: font-mermaid
             title: "Font Typeface — Mermaid.js"
+            title.zh: "字体：Mermaid.js"
+            title.zh-TW: "字型：Mermaid.js"
             type: variable-text
             document: AB02-Set-Typography
             description: Changes font for the in-built Mermaid.js visualisations in the theme.
+            description.zh: "更改主题内置 Mermaid.js 图表的字体。"
+            description.zh-TW: "更改主題內建 Mermaid.js 圖表的字型。"
             default: '"Inter 4.1", "DM Sans", "Manrope"'
     -
         id: bold-italic-settings
         title: Bold and Italic
+        title.zh: "粗体与斜体"
+        title.zh-TW: "粗體與斜體"
         type: heading
         description: "Controls options for bold and italic text across Obsidian."
+        description.zh: "控制 Obsidian 全局粗体和斜体文本的样式。"
+        description.zh-TW: "控制 Obsidian 全域粗體和斜體文本的樣式。"
         level: 2
         collapsed: false
     -
         id: bold-color-settings
         title: Bold Text
+        title.zh: "粗体文本"
+        title.zh-TW: "粗體文本"
         type: heading
         level: 3
         collapsed: false
     -
         id: bold-modifier
         title: Font Weight Modifier of Bold Text
+        title.zh: "粗体文本字重增量"
+        title.zh-TW: "粗體文本字重增量"
         type: variable-number-slider
         description: "Adjusts the font weight for bold text, on top of the usual font weight for normal text. The default is 200."
+        description.zh: "在普通文本字重的基础上，为粗体文本增加字重。默认增量为 200。"
+        description.zh-TW: "在普通文本字重的基礎上，為粗體文本增加字重。預設增量為 200。"
         min: -300
         max: 300
         step: 100
@@ -41527,6 +41613,8 @@ settings:
     -
         id: bold-color-light
         title: "Colour of Bold Text (Light Mode)"
+        title.zh: "粗体文本颜色（浅色模式）"
+        title.zh-TW: "粗體文本顏色（淺色模式）"
         type: variable-select
         allowEmpty: false
         default: 'inherit'
@@ -41588,6 +41676,8 @@ settings:
     -
         id: bold-color-dark
         title: "Colour of Bold Text (Dark Mode)"
+        title.zh: "粗体文本颜色（深色模式）"
+        title.zh-TW: "粗體文本顏色（深色模式）"
         type: variable-select
         allowEmpty: false
         default: 'inherit'
@@ -41649,14 +41739,20 @@ settings:
     -
         id: italic-color-settings
         title: Italic Text
+        title.zh: "斜体文本"
+        title.zh-TW: "斜體文本"
         type: heading
         level: 3
         collapsed: false
     -
             id: italic-weight
             title: Font Weight
+            title.zh: "字重"
+            title.zh-TW: "字重"
             type: variable-number-slider
             description: "Controls the font weight for italic text. The default is 400 (normal)."
+            description.zh: "控制斜体文本的字重。默认为 400（常规）。"
+            description.zh-TW: "控制斜體文本的字重。預設為 400（常規）。"
             min: 100
             max: 900
             step: 100
@@ -41664,6 +41760,8 @@ settings:
     -
         id: italic-color-light
         title: "Colour of Italic Text (Light Mode)"
+        title.zh: "斜体文本颜色（浅色模式）"
+        title.zh-TW: "斜體文本顏色（淺色模式）"
         type: variable-select
         allowEmpty: false
         default: 'inherit'
@@ -41725,6 +41823,8 @@ settings:
     -
         id: italic-color-dark
         title: "Colour of Bold Text (Dark Mode)"
+        title.zh: "粗体文本颜色（深色模式）"
+        title.zh-TW: "粗體文本顏色（深色模式）"
         type: variable-select
         allowEmpty: false
         default: 'inherit'
@@ -41786,23 +41886,35 @@ settings:
     -
         id: typography-underlines
         title: Underlines
+        title.zh: "下划线"
+        title.zh-TW: "底線"
         description: Options to shift underlines lower/increase underline spacing (to increase readability) or to retain it as per default.
+        description.zh: "可将下划线下移、增大与文本的间距以提高可读性，也可保留默认间距。"
+        description.zh-TW: "可將底線下移、增大與文本的間距以提高可讀性，也可保留預設間距。"
         type: heading
         level: 2
         collapsed: false
     -
         id: ssopt-typ-undl-skip-ink
         title: Skip Ink for Underlines
+        title.zh: "下划线避开字形"
+        title.zh-TW: "底線避開字形"
         type: class-toggle
         document: ET12-Underlines
         description: 'Willemstad by default does not have a space in the underline (also known as "skip ink") between interfering descenders (the bottom portion of letters "g, j, q, p, y"). This option restores the skip ink, which is also the original option in Obsidian.'
+        description.zh: "Willemstad 默认让下划线连续穿过字母 g、j、q、p、y 的下伸部分。此项恢复 Obsidian 原有的“避开字形”效果，在相交处留出空隙。"
+        description.zh-TW: "Willemstad 預設讓底線連續穿過字母 g、j、q、p、y 的下伸部分。此項恢復 Obsidian 原有的“避開字形”效果，在相交處留出空隙。"
         default: false
     -
         id: undl-text-norm
         title: Underlines Spacing — Normal Text
+        title.zh: "下划线间距：普通文本"
+        title.zh-TW: "底線間距：普通文本"
         type: class-select
         document: ET12-Underlines
         description: Choose which underline spacing you would like your normal text to have.
+        description.zh: "选择普通文本的下划线间距。"
+        description.zh-TW: "選擇普通文本的底線間距。"
         allowEmpty: false
         default: default
         options:
@@ -41818,9 +41930,13 @@ settings:
     -
         id: undl-hlink
         title: Underlines Spacing — Hyperlinks
+        title.zh: "下划线间距：超链接"
+        title.zh-TW: "底線間距：超連結"
         type: class-select
         document: ET12-Underlines
         description: Choose which underline spacing you would like your hyperlinks to have.
+        description.zh: "选择超链接的下划线间距。"
+        description.zh-TW: "選擇超連結的底線間距。"
         allowEmpty: false
         default: default
         options:
@@ -41842,21 +41958,33 @@ settings:
     -
         id: willemstad-theme-colours-light
         title: Light Mode
+        title.zh: "浅色模式"
+        title.zh-TW: "淺色模式"
         description: "Options to manipulate colours in light mode. Click any of the headers within to reveal options to change their respective color palettes."
+        description.zh: "调整浅色模式的配色。展开各标题可修改相应的配色方案。"
+        description.zh-TW: "調整淺色模式的配色。展開各標題可修改相應的配色方案。"
         type: heading
         level: 2
         collapsed: false
     -
             id: V3-willemstad-color-base-settings-light
             title: "--color-base"
+            title.zh: "基础配色（--color-base）"
+            title.zh-TW: "基礎配色（--color-base）"
             description: Background and Text
+            description.zh: "背景与文本"
+            description.zh-TW: "背景與文本"
             type: heading
             level: 3
             collapsed: true
     -
                 id: color-base-l-l-presets
                 title: "Presets for Base Lightness"
+                title.zh: "基础明度预设"
+                title.zh-TW: "基礎明度預設"
                 description: "Choose the amount of contrast you would prefer between your background and text elements."
+                description.zh: "选择背景与文本之间的对比强度。"
+                description.zh-TW: "選擇背景與文本之間的對比強度。"
                 type: class-select
                 allowEmpty: false
                 default: default
@@ -41906,7 +42034,11 @@ settings:
     -
                 id: color-base-l-ch-presets
                 title: "Presets for Base Tone (Chroma and Hue)"
+                title.zh: "基础色调预设（彩度和色相）"
+                title.zh-TW: "基礎色調預設（彩度和色相）"
                 description: "Choose the color temperature and hue palette for your light theme. Some options are recommended with or require base lightness setting for better/true colours, please adjust your settings accordingly."
+                description.zh: "选择浅色主题的色温与色相方案。某些方案建议或要求搭配特定基础明度，才能呈现理想或准确的颜色，请相应调整。"
+                description.zh-TW: "選擇淺色主題的色溫與色相方案。某些方案建議或要求搭配特定基礎明度，才能呈現理想或準確的顏色，請相應調整。"
                 type: class-select
                 allowEmpty: false
                 default: default
@@ -42262,18 +42394,26 @@ settings:
     -
                 id: V4-willemstad-color-base-variations-light
                 title: Custom Settings
+                title.zh: "自定义设置"
+                title.zh-TW: "自訂設定"
                 type: heading
                 level: 4
                 collapsed: true
     -
                     id: ssopt-custom-base-colours-light
                     title: 'Enable User-Set Base Tone for Light Mode'
+                    title.zh: "启用浅色模式自定义基础色调"
+                    title.zh-TW: "啟用淺色模式自訂基礎色調"
                     type: class-toggle
                     description: "When enabled, this allows you to override preset base tones (chroma and hue) with your preferred one."
+                    description.zh: "启用后，可用自定义彩度和色相覆盖基础色调预设。"
+                    description.zh-TW: "啟用後，可用自訂彩度和色相覆蓋基礎色調預設。"
                     default: false
     -
                         id: ch-color-base-l-c-pax-num
                         title: "Chroma"
+                        title.zh: "彩度"
+                        title.zh-TW: "彩度"
                         type: variable-number-slider
                         min: 0
                         max: 0.07
@@ -42282,6 +42422,8 @@ settings:
     -
                         id: ch-color-base-l-h-pax-num
                         title: "Hue"
+                        title.zh: "色相"
+                        title.zh-TW: "色相"
                         type: variable-number-slider
                         min: 0
                         max: 360
@@ -42290,12 +42432,18 @@ settings:
     -
                         id: ssopt-enable-base-delta-light
                         title: 'Enable Chroma & Hue Delta (Gradient Effect)'
+                        title.zh: "启用彩度和色相变化量（渐变效果）"
+                        title.zh-TW: "啟用彩度和色相變化量（漸變效果）"
                         type: class-toggle
                         description: "When enabled, this applies a range (delta) to the base chroma and hue, creating a subtle gradient effect across different UI layers. A delta of 0 results in no change. Please note that this effect is very subtle."
+                        description.zh: "启用后，为基础彩度和色相加入变化量，在不同界面层级之间产生轻微渐变。变化量为 0 时不改变颜色。此效果通常十分细微。"
+                        description.zh-TW: "啟用後，為基礎彩度和色相加入變化量，在不同介面層級之間產生輕微漸變。變化量為 0 時不改變顏色。此效果通常十分細微。"
                         default: false
     -
                             id: ch-color-base-l-c-pax-delta
                             title: "Chroma Delta (Δ)"
+                            title.zh: "彩度变化量（Δ）"
+                            title.zh-TW: "彩度變化量（Δ）"
                             type: variable-number-slider
                             min: -0.10
                             max: 0.10
@@ -42304,6 +42452,8 @@ settings:
     -
                             id: ch-color-base-l-h-pax-delta
                             title: "Hue Delta (Δ)"
+                            title.zh: "色相变化量（Δ）"
+                            title.zh-TW: "色相變化量（Δ）"
                             type: variable-number-slider
                             min: -60
                             max: 60
@@ -42312,13 +42462,19 @@ settings:
     -
             id: V3-willemstad-color-accent-settings-light
             title: "--color-accent"
+            title.zh: "强调色（--color-accent）"
+            title.zh-TW: "強調色（--color-accent）"
             description: Accents and Interactives
+            description.zh: "强调色与交互元素"
+            description.zh-TW: "強調色與互動元素"
             type: heading
             level: 3
             collapsed: true
     -
                 id: color-accent-l-ch-presets
                 title: "Presets for Accent Colours"
+                title.zh: "强调色预设"
+                title.zh-TW: "強調色預設"
                 description: ""
                 type: class-select
                 allowEmpty: false
@@ -43512,26 +43668,40 @@ settings:
     -
                 id: V4-willemstad-color-accent-variations-light
                 title: Custom Settings
+                title.zh: "自定义设置"
+                title.zh-TW: "自訂設定"
                 type: heading
                 level: 4
                 collapsed: true
     -
                     id: ssopt-custom-accent-colours-light
                     title: 'Enable User-Set Accents for Light Mode'
+                    title.zh: "启用浅色模式自定义强调色"
+                    title.zh-TW: "啟用淺色模式自訂強調色"
                     type: class-toggle
                     description: "When enabled, this allows you to override preset accents with your preferred ones."
+                    description.zh: "启用后，可用自定义颜色覆盖强调色预设。"
+                    description.zh-TW: "啟用後，可用自訂顏色覆蓋強調色預設。"
                     default: false
     -
                         id: info-about-colour-theory-accent-l
                         title: 'A Brief Lesson on Colour Theory Before You Start'
+                        title.zh: "开始之前：色彩理论简介"
+                        title.zh-TW: "開始之前：色彩理論簡介"
                         type: info-text
                         description: "Colours can be organized on a 360° hue wheel to create specific harmonies. Analogous colours, which are close neighbours on the wheel (typically 15-45° apart), produce a calm and gentle effect. For a more vibrant yet balanced feel, a triadic scheme uses three colours spaced exactly 120° apart. A split-complementary harmony offers high contrast with less tension by pairing one colour with the two neighbours of its direct opposite."
+                        description.zh: "颜色可按色相排列在 360° 色环上，形成不同配色关系。相邻约 15-45° 的类似色较为平静柔和；彼此相隔 120° 的三角色既鲜明又平衡；分裂互补色则将一种颜色与其互补色两侧的颜色搭配，在保持高对比的同时减轻冲突感。"
+                        description.zh-TW: "顏色可按色相排列在 360° 色環上，形成不同配色關係。相鄰約 15-45° 的類似色較為平靜柔和；彼此相隔 120° 的三角色既鮮明又平衡；分裂互補色則將一種顏色與其互補色兩側的顏色搭配，在保持高對比的同時減輕衝突感。"
                         default: false
     -
                         id: color-pax-l-accent-h-shift
                         title: 'Set Hue Range for Accents'
+                        title.zh: "设置强调色色相范围"
+                        title.zh-TW: "設定強調色色相範圍"
                         type: variable-number-slider
                         description: 'Adjust the hue shift to create different colour harmonies. 0° = monochromatic, 30-60° = analogous, 90° = tetradic, 120° = triadic, 150° = split-complementary, 180° = complementary.'
+                        description.zh: "调整色相偏移以形成不同配色关系：0° 为单色，30-60° 为类似色，90° 为四角色，120° 为三角色，150° 为分裂互补色，180° 为互补色。"
+                        description.zh-TW: "調整色相偏移以形成不同配色關係：0° 為單色，30-60° 為類似色，90° 為四角色，120° 為三角色，150° 為分裂互補色，180° 為互補色。"
                         format: ''
                         default: 0
                         min: 0
@@ -43541,8 +43711,12 @@ settings:
     -
                         id: color-pax-l-accent-l-shift
                         title: 'Set Lightness Range for Accents'
+                        title.zh: "设置强调色明度范围"
+                        title.zh-TW: "設定強調色明度範圍"
                         type: variable-number-slider
                         description: 'Control how much darker each accent becomes. Higher values create more contrast between accent variations. Recommended: 5-15% (0.05-0.15) for subtle differences, 15-25% (0.15-0.25) for distinct variations.'
+                        description.zh: "控制各级强调色的明度递减幅度。数值越大，各级颜色的对比越强。建议轻微变化使用 5-15%（0.05-0.15），明显变化使用 15-25%（0.15-0.25）。"
+                        description.zh-TW: "控制各級強調色的明度遞減幅度。數值越大，各級顏色的對比越強。建議輕微變化使用 5-15%（0.05-0.15），明顯變化使用 15-25%（0.15-0.25）。"
                         format: ''
                         default: 0.1
                         min: 0
@@ -43551,53 +43725,85 @@ settings:
     -
                         id: color-pax-l-accent-picker
                         title: 'Accent Color via Picker'
+                        title.zh: "使用取色器设置强调色"
+                        title.zh-TW: "使用取色器設定強調色"
                         type: variable-color
                         description: 'The primary accent color for light mode. This will be used to generate additional accent variations based on your hue and lightness shift settings.'
+                        description.zh: "浅色模式的主强调色。其他强调色会根据此颜色以及色相、明度偏移设置生成。"
+                        description.zh-TW: "淺色模式的主強調色。其他強調色會根據此顏色以及色相、明度偏移設定生成。"
                         opacity: false
                         format: hsl
                         default: 'hsl(184 74% 20%)'
     -
                         id: ssopt-custom-accent-textfield-light
                         title: "Set Accents via Text Field Instead"
+                        title.zh: "改用文本输入设置强调色"
+                        title.zh-TW: "改用文本輸入設定強調色"
                         type: class-toggle
                         description: "Use a text field instead of a colour picker for your primary accent. Accepts any valid CSS colour format (e.g., hex, RGB(A), HSL, OKLCH, var(--interactive-accent))."
+                        description.zh: "使用文本输入框代替取色器设置主强调色。接受有效的 CSS 颜色格式，例如 hex、RGB(A)、HSL、OKLCH 或 var(--interactive-accent)。"
+                        description.zh-TW: "使用文本輸入框代替取色器設定主強調色。接受有效的 CSS 顏色格式，例如 hex、RGB(A)、HSL、OKLCH 或 var(--interactive-accent)。"
                         default: false
     -
                         id: color-pax-l-accent-textfield
                         title: 'Custom Accent Colour'
+                        title.zh: "自定义强调色"
+                        title.zh-TW: "自訂強調色"
                         type: variable-text
                         default: ''
                         description: 'Overrides the default accent colour. If left empty, defaults to the preset accent. Accepts any valid CSS colour format (e.g., hex, RGB(A), HSL, OKLCH, var(--interactive-accent)).'  
+                        description.zh: "覆盖默认强调色。留空时使用预设。接受有效的 CSS 颜色格式，例如 hex、RGB(A)、HSL、OKLCH 或 var(--interactive-accent)。"
+                        description.zh-TW: "覆蓋預設強調色。留空時使用預設。接受有效的 CSS 顏色格式，例如 hex、RGB(A)、HSL、OKLCH 或 var(--interactive-accent)。"
     -
                         id: ssopt-custom-accents-total-enable-light
                         title: "Enable Fully Custom Accents"
+                        title.zh: "启用完全自定义强调色"
+                        title.zh-TW: "啟用完全自訂強調色"
                         type: class-toggle
                         description: "When enabled, lets you override the secondary and tertiary accent colours (--color-accent-1 and --color-accent-2) using the fields below."
+                        description.zh: "启用后，可通过下方字段覆盖第二、第三强调色（--color-accent-1 和 --color-accent-2）。"
+                        description.zh-TW: "啟用後，可通過下方欄位覆蓋第二、第三強調色（--color-accent-1 和 --color-accent-2）。"
                         default: false
     -
                         id: 'color-pax-l-accent-1-textfield'
                         title: "Custom Accent Colour — Secondary"
+                        title.zh: "自定义第二强调色"
+                        title.zh-TW: "自訂第二強調色"
                         type: variable-text
                         default: ''
                         description: "Overrides the default secondary accent colour. If left empty, falls back to the preset. Accepts any valid CSS colour format (e.g., hex, RGB, HSL, OKLCH)."
+                        description.zh: "覆盖默认第二强调色。留空时使用预设。接受有效的 CSS 颜色格式，例如 hex、RGB、HSL 或 OKLCH。"
+                        description.zh-TW: "覆蓋預設第二強調色。留空時使用預設。接受有效的 CSS 顏色格式，例如 hex、RGB、HSL 或 OKLCH。"
     -
                         id: 'color-pax-l-accent-2-textfield'
                         title: "Custom Accent Colour — Tertiary"
+                        title.zh: "自定义第三强调色"
+                        title.zh-TW: "自訂第三強調色"
                         type: variable-text
                         default: ''
                         description: "Overrides the default tertiary accent colour. If left empty, falls back to the preset. Accepts any valid CSS colour format (e.g., hex, RGB, HSL, OKLCH)."
+                        description.zh: "覆盖默认第三强调色。留空时使用预设。接受有效的 CSS 颜色格式，例如 hex、RGB、HSL 或 OKLCH。"
+                        description.zh-TW: "覆蓋預設第三強調色。留空時使用預設。接受有效的 CSS 顏色格式，例如 hex、RGB、HSL 或 OKLCH。"
     -
             id: V3-willemstad-color-rainbow-settings-light
             title: "Rainbow Colours"
+            title.zh: "彩虹色"
+            title.zh-TW: "彩虹色"
             description: "Red, Orange, Yellow, Green, Cyan, Blue, Purple and Pink"
+            description.zh: "红、橙、黄、绿、青、蓝、紫、粉"
+            description.zh-TW: "紅、橙、黃、綠、青、藍、紫、粉"
             type: heading
             level: 3
             collapsed: true
     -
                 id: color-rainbow-l-presets
                 title: "Presets for Rainbow Colours (Light)"
+                title.zh: "彩虹色预设（浅色模式）"
+                title.zh-TW: "彩虹色預設（淺色模式）"
                 type: class-select
                 description: "Presets might not cleanly fit into Obsidian's specific colour palette."
+                description.zh: "预设颜色可能无法完全对应 Obsidian 指定的色彩分类。"
+                description.zh-TW: "預設顏色可能無法完全對應 Obsidian 指定的色彩分類。"
                 allowEmpty: false
                 default: default
                 options:
@@ -43727,74 +43933,120 @@ settings:
     -
                 id: V4-willemstad-color-rainbows-variations-light
                 title: Custom Settings
+                title.zh: "自定义设置"
+                title.zh-TW: "自訂設定"
                 type: heading
                 level: 4
                 collapsed: true
     -
                 id: ssopt-custom-rainbow-colours-light
                 title: 'Enable User-Set Rainbow Colours for Light Mode'
+                title.zh: "启用浅色模式自定义彩虹色"
+                title.zh-TW: "啟用淺色模式自訂彩虹色"
                 type: class-toggle
                 description: "When enabled, this allows you to override preset rainbow colours with your preferred colours. Rainbow colours not overriden will use the prevailing colour available in the preset."
+                description.zh: "启用后，可覆盖彩虹色预设。未单独覆盖的颜色仍使用当前预设。"
+                description.zh-TW: "啟用後，可覆蓋彩虹色預設。未單獨覆蓋的顏色仍使用當前預設。"
                 default: false
     -
                     id: color-pax-l-red
                     title: 'Custom Colour — Red'
+                    title.zh: "自定义颜色：红色"
+                    title.zh-TW: "自訂顏色：紅色"
                     type: variable-text
                     default: ''
                     description: 'Overrides the default Red colour. If left empty, defaults to the preset colour. Accepts all valid CSS colour values (e.g., hex, RGB, HSL, var(--interactive-accent)).'
+                    description.zh: "覆盖默认红色。留空时使用预设。接受有效的 CSS 颜色值，例如 hex、RGB、HSL 或 var(--interactive-accent)。"
+                    description.zh-TW: "覆蓋預設紅色。留空時使用預設。接受有效的 CSS 顏色值，例如 hex、RGB、HSL 或 var(--interactive-accent)。"
     -
                     id: color-pax-l-orange
                     title: 'Custom Colour — Orange'
+                    title.zh: "自定义颜色：橙色"
+                    title.zh-TW: "自訂顏色：橙色"
                     type: variable-text
                     default: ''
                     description: 'Overrides the default Orange colour. If left empty, defaults to the preset colour. Accepts all valid CSS colour values (e.g., hex, RGB, HSL, var(--interactive-accent)).'
+                    description.zh: "覆盖默认橙色。留空时使用预设。接受有效的 CSS 颜色值，例如 hex、RGB、HSL 或 var(--interactive-accent)。"
+                    description.zh-TW: "覆蓋預設橙色。留空時使用預設。接受有效的 CSS 顏色值，例如 hex、RGB、HSL 或 var(--interactive-accent)。"
     -
                     id: color-pax-l-yellow
                     title: 'Custom Colour — Yellow'
+                    title.zh: "自定义颜色：黄色"
+                    title.zh-TW: "自訂顏色：黃色"
                     type: variable-text
                     default: ''
                     description: 'Overrides the default Yellow colour. If left empty, defaults to the preset colour. Accepts all valid CSS colour values (e.g., hex, RGB, HSL, var(--interactive-accent)).'
+                    description.zh: "覆盖默认黄色。留空时使用预设。接受有效的 CSS 颜色值，例如 hex、RGB、HSL 或 var(--interactive-accent)。"
+                    description.zh-TW: "覆蓋預設黃色。留空時使用預設。接受有效的 CSS 顏色值，例如 hex、RGB、HSL 或 var(--interactive-accent)。"
     -
                     id: color-pax-l-green
                     title: 'Custom Colour — Green'
+                    title.zh: "自定义颜色：绿色"
+                    title.zh-TW: "自訂顏色：綠色"
                     type: variable-text
                     default: ''
                     description: 'Overrides the default Green colour. If left empty, defaults to the preset colour. Accepts all valid CSS colour values (e.g., hex, RGB, HSL, var(--interactive-accent)).'
+                    description.zh: "覆盖默认绿色。留空时使用预设。接受有效的 CSS 颜色值，例如 hex、RGB、HSL 或 var(--interactive-accent)。"
+                    description.zh-TW: "覆蓋預設綠色。留空時使用預設。接受有效的 CSS 顏色值，例如 hex、RGB、HSL 或 var(--interactive-accent)。"
     -
                     id: color-pax-l-cyan
                     title: 'Custom Colour — Cyan'
+                    title.zh: "自定义颜色：青色"
+                    title.zh-TW: "自訂顏色：青色"
                     type: variable-text
                     default: ''
                     description: 'Overrides the default Cyan colour. If left empty, defaults to the preset colour. Accepts all valid CSS colour values (e.g., hex, RGB, HSL, var(--interactive-accent)).'
+                    description.zh: "覆盖默认青色。留空时使用预设。接受有效的 CSS 颜色值，例如 hex、RGB、HSL 或 var(--interactive-accent)。"
+                    description.zh-TW: "覆蓋預設青色。留空時使用預設。接受有效的 CSS 顏色值，例如 hex、RGB、HSL 或 var(--interactive-accent)。"
     -
                     id: color-pax-l-blue
                     title: 'Custom Colour — Blue'
+                    title.zh: "自定义颜色：蓝色"
+                    title.zh-TW: "自訂顏色：藍色"
                     type: variable-text
                     default: ''
                     description: 'Overrides the default Blue colour. If left empty, defaults to the preset colour. Accepts all valid CSS colour values (e.g., hex, RGB, HSL, var(--interactive-accent)).'
+                    description.zh: "覆盖默认蓝色。留空时使用预设。接受有效的 CSS 颜色值，例如 hex、RGB、HSL 或 var(--interactive-accent)。"
+                    description.zh-TW: "覆蓋預設藍色。留空時使用預設。接受有效的 CSS 顏色值，例如 hex、RGB、HSL 或 var(--interactive-accent)。"
     -
                     id: color-pax-l-purple
                     title: 'Custom Colour — Purple'
+                    title.zh: "自定义颜色：紫色"
+                    title.zh-TW: "自訂顏色：紫色"
                     type: variable-text
                     default: ''
                     description: 'Overrides the default Purple colour. If left empty, defaults to the preset colour. Accepts all valid CSS colour values (e.g., hex, RGB, HSL, var(--interactive-accent)).'
+                    description.zh: "覆盖默认紫色。留空时使用预设。接受有效的 CSS 颜色值，例如 hex、RGB、HSL 或 var(--interactive-accent)。"
+                    description.zh-TW: "覆蓋預設紫色。留空時使用預設。接受有效的 CSS 顏色值，例如 hex、RGB、HSL 或 var(--interactive-accent)。"
     -
                     id: color-pax-l-pink
                     title: 'Custom Colour — Pink'
+                    title.zh: "自定义颜色：粉色"
+                    title.zh-TW: "自訂顏色：粉色"
                     type: variable-text
                     default: ''
                     description: 'Overrides the default Pink colour. If left empty, defaults to the preset colour. Accepts all valid CSS colour values (e.g., hex, RGB, HSL, var(--interactive-accent)).'
+                    description.zh: "覆盖默认粉色。留空时使用预设。接受有效的 CSS 颜色值，例如 hex、RGB、HSL 或 var(--interactive-accent)。"
+                    description.zh-TW: "覆蓋預設粉色。留空時使用預設。接受有效的 CSS 顏色值，例如 hex、RGB、HSL 或 var(--interactive-accent)。"
     -
         id: V3-willemstad-color-selection-settings-light
         title: "--text-selection"
+        title.zh: "文本选区（--text-selection）"
+        title.zh-TW: "文本選區（--text-selection）"
         description: "Text Selection and Highlights"
+        description.zh: "文本选区与高亮"
+        description.zh-TW: "文本選區與高亮"
         type: heading
         level: 3
         collapsed: true
     -
         id: col-selection-l-presets
         title: "Presets for Selection Colour"
+        title.zh: "选区颜色预设"
+        title.zh-TW: "選區顏色預設"
         description: "Choose a color for selected text."
+        description.zh: "选择文本选区的颜色。"
+        description.zh-TW: "選擇文本選區的顏色。"
         type: class-select
         allowEmpty: false
         default: ssopt-sel-l-default-yellow
@@ -43844,80 +44096,126 @@ settings:
     -
             id: V4-willemstad-color-selection-variations-light
             title: Custom Settings
+            title.zh: "自定义设置"
+            title.zh-TW: "自訂設定"
             type: heading
             level: 4
             collapsed: true
     -
             id: ssopt-custom-selection-colours-light
             title: 'Enable User-Set Selection Colour for Light Mode'
+            title.zh: "启用浅色模式自定义选区颜色"
+            title.zh-TW: "啟用淺色模式自訂選區顏色"
             type: class-toggle
             description: "When enabled, this allows you to override the preset selection colour with your preferred colour. If left empty, it will use the prevailing colour from the selected preset."
+            description.zh: "启用后，可覆盖选区颜色预设。留空时使用当前预设的颜色。"
+            description.zh-TW: "啟用後，可覆蓋選區顏色預設。留空時使用當前預設的顏色。"
             default: false
     -
                 id: color-pax-l-selection
                 title: 'Custom Selection Colour'
+                title.zh: "自定义选区颜色"
+                title.zh-TW: "自訂選區顏色"
                 type: variable-text
                 default: ''
                 description: 'Overrides the default selection colour. If left empty, defaults to the preset colour. Accepts all valid CSS colour values (e.g., hex, RGB, HSL, var(--interactive-accent)).'
+                description.zh: "覆盖默认选区颜色。留空时使用预设。接受有效的 CSS 颜色值，例如 hex、RGB、HSL 或 var(--interactive-accent)。"
+                description.zh-TW: "覆蓋預設選區顏色。留空時使用預設。接受有效的 CSS 顏色值，例如 hex、RGB、HSL 或 var(--interactive-accent)。"
     -
             id: V3-willemstad-color-contrast-settings-light
             title: 'Cross-Colour UI (Dark UI)'
+            title.zh: "跨模式配色界面（深色界面）"
+            title.zh-TW: "跨模式配色介面（深色介面）"
             type: heading
             level: 3
             collapsed: true
     -
                 id: ssopt-theme-contrast-light
                 title: Enable Contrast
+                title.zh: "启用对比配色"
+                title.zh-TW: "啟用對比配色"
                 type: class-toggle
                 description: "When enabled, UI elements like the titlebar, ribbon, status bar, and side panes will use a contrasting colour scheme taken from the current mode's chroma and hue."
+                description.zh: "启用后，标题栏、侧边工具栏、状态栏和侧边面板等界面元素使用由当前模式彩度与色相生成的对比配色。"
+                description.zh-TW: "啟用後，標題列、側邊工具列、狀態列和側邊面板等介面元素使用由當前模式彩度與色相生成的對比配色。"
                 default: false
     -
                 id: ssopt-tc-cross-l
                 title: Use Base Colours from Dark Mode
+                title.zh: "使用深色模式的基础配色"
+                title.zh-TW: "使用深色模式的基礎配色"
                 type: class-toggle
                 description: "Imports the base background and text colours from your dark mode settings to use for the contrasting UI elements. The base colours within your main editing workspace will not be affected."
+                description.zh: "从深色模式设置导入背景和文本基础配色，用于对比界面元素。主编辑工作区的基础配色不受影响。"
+                description.zh-TW: "從深色模式設定匯入背景和文本基礎配色，用於對比介面元素。主編輯工作區的基礎配色不受影響。"
                 default: false
     -
                 id: ssopt-tc-accent-cross-l
                 title: Use Accent Colours from Dark Mode
+                title.zh: "使用深色模式的强调色"
+                title.zh-TW: "使用深色模式的強調色"
                 type: class-toggle
                 description: "Imports the accent colours from your dark mode settings to use for the contrasting UI elements. The accent colours within your main editing workspace will not be affected."
+                description.zh: "从深色模式设置导入强调色，用于对比界面元素。主编辑工作区的强调色不受影响。"
+                description.zh-TW: "從深色模式設定匯入強調色，用於對比介面元素。主編輯工作區的強調色不受影響。"
                 default: false
     -
             id: info-override-template-light
             title: Override via Custom Template Snippet
+            title.zh: "使用自定义模板代码片段覆盖配色"
+            title.zh-TW: "使用自訂模板程式碼片段覆蓋配色"
             type: heading
             level: 3
             collapsed: true
     -
                 id: ssopt-custom-colour-template-light
                 title: Enable User-Set Colours via Template for Light Mode
+                title.zh: "启用浅色模式模板自定义配色"
+                title.zh-TW: "啟用淺色模式模板自訂配色"
                 description: "Enable this option to allow the use of a snippet, for specific preset variables which will customize colors for the theme's appearance in light mode. This will override the variables set within Style Settings."
+                description.zh: "启用后，可用包含指定预设变量的代码片段自定义浅色模式配色。这会覆盖 Style Settings 中设置的变量。"
+                description.zh-TW: "啟用後，可用包含指定預設變數的程式碼片段自訂淺色模式配色。這會覆蓋 Style Settings 中設定的變數。"
                 type: class-toggle
     -
                 id: info-template-file-light
                 title: Template Snippet File
+                title.zh: "模板代码片段文件"
+                title.zh-TW: "模板程式碼片段檔案"
                 description: "[Template File](https://willemstad.cc/Dev+Docs/Template+Snippet)"
+                description.zh: "[模板文件](https://willemstad.cc/Dev+Docs/Template+Snippet)"
+                description.zh-TW: "[模板檔案](https://willemstad.cc/Dev+Docs/Template+Snippet)"
                 type: info-text
                 markdown: true
     -
         id: willemstad-theme-colours-dark
         title: Dark Mode
+        title.zh: "深色模式"
+        title.zh-TW: "深色模式"
         description: "Options to manipulate colours in dark mode. Click any of the headers within to reveal options to change their respective color palettes."
+        description.zh: "调整深色模式的配色。展开各标题可修改相应的配色方案。"
+        description.zh-TW: "調整深色模式的配色。展開各標題可修改相應的配色方案。"
         type: heading
         level: 2
         collapsed: false
     -
             id: V3-willemstad-color-base-settings-dark
             title: "--color-base"
+            title.zh: "基础配色（--color-base）"
+            title.zh-TW: "基礎配色（--color-base）"
             description: Background and Text
+            description.zh: "背景与文本"
+            description.zh-TW: "背景與文本"
             type: heading
             level: 3
             collapsed: true
     -
                 id: color-base-d-l-presets
                 description: "Choose the amount of contrast you would prefer between your background and text elements."
+                description.zh: "选择背景与文本之间的对比强度。"
+                description.zh-TW: "選擇背景與文本之間的對比強度。"
                 title: "Presets for Base Lightness"
+                title.zh: "基础明度预设"
+                title.zh-TW: "基礎明度預設"
                 type: class-select
                 allowEmpty: false
                 default: default
@@ -43973,7 +44271,11 @@ settings:
     -
                 id: color-base-d-ch-presets
                 title: "Presets for Base Tone (Chroma and Hue)"
+                title.zh: "基础色调预设（彩度和色相）"
+                title.zh-TW: "基礎色調預設（彩度和色相）"
                 description: "Choose the color temperature and hue palette for your dark theme. Some options are recommended with or require base lightness setting for better/true colours, please adjust your settings accordingly."
+                description.zh: "选择深色主题的色温与色相方案。某些方案建议或要求搭配特定基础明度，才能呈现理想或准确的颜色，请相应调整。"
+                description.zh-TW: "選擇深色主題的色溫與色相方案。某些方案建議或要求搭配特定基礎明度，才能呈現理想或準確的顏色，請相應調整。"
                 type: class-select
                 allowEmpty: false
                 default: default
@@ -44335,18 +44637,26 @@ settings:
     -
             id: V4-willemstad-color-base-variations-dark
             title: Custom Settings
+            title.zh: "自定义设置"
+            title.zh-TW: "自訂設定"
             type: heading
             level: 4
             collapsed: true
     -
                 id: ssopt-custom-base-colours-dark
                 title: 'Enable User-Set Base Tone for Dark Mode'
+                title.zh: "启用深色模式自定义基础色调"
+                title.zh-TW: "啟用深色模式自訂基礎色調"
                 type: class-toggle
                 description: "When enabled, this allows you to override preset base tones (chroma and hue) with your preferred one."
+                description.zh: "启用后，可用自定义彩度和色相覆盖基础色调预设。"
+                description.zh-TW: "啟用後，可用自訂彩度和色相覆蓋基礎色調預設。"
                 default: false
     -
                 id: ch-color-base-d-c-pax-num
                 title: "Base Chroma"
+                title.zh: "基础彩度"
+                title.zh-TW: "基礎彩度"
                 type: variable-number-slider
                 min: 0
                 max: 0.07
@@ -44355,6 +44665,8 @@ settings:
     -
                 id: ch-color-base-d-h-pax-num
                 title: "Base Hue"
+                title.zh: "基础色相"
+                title.zh-TW: "基礎色相"
                 type: variable-number-slider
                 min: 0
                 max: 360
@@ -44363,12 +44675,18 @@ settings:
     -
                     id: ssopt-enable-base-delta-dark
                     title: 'Enable Chroma & Hue Delta (Gradient Effect)'
+                    title.zh: "启用彩度和色相变化量（渐变效果）"
+                    title.zh-TW: "啟用彩度和色相變化量（漸變效果）"
                     type: class-toggle
                     description: "When enabled, this applies a range (delta) to the base chroma and hue, creating a subtle gradient effect across different UI layers. A delta of 0 results in no change. Please note that this effect is very subtle."
+                    description.zh: "启用后，为基础彩度和色相加入变化量，在不同界面层级之间产生轻微渐变。变化量为 0 时不改变颜色。此效果通常十分细微。"
+                    description.zh-TW: "啟用後，為基礎彩度和色相加入變化量，在不同介面層級之間產生輕微漸變。變化量為 0 時不改變顏色。此效果通常十分細微。"
                     default: false
     -
                     id: ch-color-base-d-c-pax-delta
                     title: "Chroma Delta (Δ)"
+                    title.zh: "彩度变化量（Δ）"
+                    title.zh-TW: "彩度變化量（Δ）"
                     type: variable-number-slider
                     min: -0.10
                     max: 0.10
@@ -44377,6 +44695,8 @@ settings:
     -
                     id: ch-color-base-d-h-pax-delta
                     title: "Hue Delta (Δ)"
+                    title.zh: "色相变化量（Δ）"
+                    title.zh-TW: "色相變化量（Δ）"
                     type: variable-number-slider
                     min: -60
                     max: 60
@@ -44385,13 +44705,19 @@ settings:
     -
             id: V3-willemstad-color-accent-settings-dark
             title: "--color-accent"
+            title.zh: "强调色（--color-accent）"
+            title.zh-TW: "強調色（--color-accent）"
             description: Accents and Interactives
+            description.zh: "强调色与交互元素"
+            description.zh-TW: "強調色與互動元素"
             type: heading
             level: 3
             collapsed: true
     -
                 id: color-accent-d-ch-presets
                 title: "Presets for Accent Colours"
+                title.zh: "强调色预设"
+                title.zh-TW: "強調色預設"
                 description: ""
                 type: class-select
                 allowEmpty: false
@@ -45585,26 +45911,40 @@ settings:
     -
                 id: V4-willemstad-color-accent-variations-dark
                 title: Custom Settings
+                title.zh: "自定义设置"
+                title.zh-TW: "自訂設定"
                 type: heading
                 level: 4
                 collapsed: true
     -
                     id: ssopt-custom-accent-colours-dark
                     title: 'Enable User-Set Accents for Dark Mode'
+                    title.zh: "启用深色模式自定义强调色"
+                    title.zh-TW: "啟用深色模式自訂強調色"
                     type: class-toggle
                     description: "When enabled, this allows you to override preset accents with your preferred ones."
+                    description.zh: "启用后，可用自定义颜色覆盖强调色预设。"
+                    description.zh-TW: "啟用後，可用自訂顏色覆蓋強調色預設。"
                     default: false
     -
                         id: info-about-colour-theory-accent-d
                         title: 'A Brief Lesson on Colour Theory Before You Start'
+                        title.zh: "开始之前：色彩理论简介"
+                        title.zh-TW: "開始之前：色彩理論簡介"
                         type: info-text
                         description: "Colours can be organized on a 360° hue wheel to create specific harmonies. Analogous colours, which are close neighbours on the wheel (typically 15-45° apart), produce a calm and gentle effect. For a more vibrant yet balanced feel, a triadic scheme uses three colours spaced exactly 120° apart. A split-complementary harmony offers high contrast with less tension by pairing one colour with the two neighbours of its direct opposite."
+                        description.zh: "颜色可按色相排列在 360° 色环上，形成不同配色关系。相邻约 15-45° 的类似色较为平静柔和；彼此相隔 120° 的三角色既鲜明又平衡；分裂互补色则将一种颜色与其互补色两侧的颜色搭配，在保持高对比的同时减轻冲突感。"
+                        description.zh-TW: "顏色可按色相排列在 360° 色環上，形成不同配色關係。相鄰約 15-45° 的類似色較為平靜柔和；彼此相隔 120° 的三角色既鮮明又平衡；分裂互補色則將一種顏色與其互補色兩側的顏色搭配，在保持高對比的同時減輕衝突感。"
                         default: false
     -
                         id: color-pax-d-accent-h-shift
                         title: 'Set Hue Range for Accents'
+                        title.zh: "设置强调色色相范围"
+                        title.zh-TW: "設定強調色色相範圍"
                         type: variable-number-slider
                         description: 'Adjust the hue shift to create different colour harmonies. 0° = monochromatic, 30-60° = analogous, 90° = tetradic, 120° = triadic, 150° = split-complementary, 180° = complementary.'
+                        description.zh: "调整色相偏移以形成不同配色关系：0° 为单色，30-60° 为类似色，90° 为四角色，120° 为三角色，150° 为分裂互补色，180° 为互补色。"
+                        description.zh-TW: "調整色相偏移以形成不同配色關係：0° 為單色，30-60° 為類似色，90° 為四角色，120° 為三角色，150° 為分裂互補色，180° 為互補色。"
                         format: ''
                         default: 0
                         min: 0
@@ -45614,8 +45954,12 @@ settings:
     -
                         id: color-pax-d-accent-l-shift
                         title: 'Set Lightness Range for Accents'
+                        title.zh: "设置强调色明度范围"
+                        title.zh-TW: "設定強調色明度範圍"
                         type: variable-number-slider
                         description: 'Control how much darker each accent becomes. Higher values create more contrast between accent variations. Recommended: 5-15% (0.05-0.15) for subtle differences, 15-25% (0.15-0.25) for distinct variations.'
+                        description.zh: "控制各级强调色的明度递减幅度。数值越大，各级颜色的对比越强。建议轻微变化使用 5-15%（0.05-0.15），明显变化使用 15-25%（0.15-0.25）。"
+                        description.zh-TW: "控制各級強調色的明度遞減幅度。數值越大，各級顏色的對比越強。建議輕微變化使用 5-15%（0.05-0.15），明顯變化使用 15-25%（0.15-0.25）。"
                         format: ''
                         default: 0.1
                         min: 0
@@ -45625,8 +45969,12 @@ settings:
     -
                         id: color-pax-d-accent-picker
                         title: 'Accent Color via Picker'
+                        title.zh: "使用取色器设置强调色"
+                        title.zh-TW: "使用取色器設定強調色"
                         type: variable-color
                         description: 'The primary accent color for light mode. This will be used to generate additional accent variations based on your hue and lightness shift settings.'
+                        description.zh: "浅色模式的主强调色。其他强调色会根据此颜色以及色相、明度偏移设置生成。"
+                        description.zh-TW: "淺色模式的主強調色。其他強調色會根據此顏色以及色相、明度偏移設定生成。"
                         opacity: false
                         format: hsl
                         default: 'hsl(184 74% 20%)'
@@ -45634,49 +45982,77 @@ settings:
     -
                             id: ssopt-custom-accent-textfield-dark
                             title: "Set Accents via Text Field Instead"
+                            title.zh: "改用文本输入设置强调色"
+                            title.zh-TW: "改用文本輸入設定強調色"
                             type: class-toggle
                             description: "Use a text field instead of a colour picker for your primary accent. Accepts any valid CSS colour format (e.g., hex, RGB(A), HSL, OKLCH, var(--interactive-accent))."
+                            description.zh: "使用文本输入框代替取色器设置主强调色。接受有效的 CSS 颜色格式，例如 hex、RGB(A)、HSL、OKLCH 或 var(--interactive-accent)。"
+                            description.zh-TW: "使用文本輸入框代替取色器設定主強調色。接受有效的 CSS 顏色格式，例如 hex、RGB(A)、HSL、OKLCH 或 var(--interactive-accent)。"
                             default: false
 
     -
                             id: color-pax-d-accent-textfield
                             title: 'Custom Accent Colour'
+                            title.zh: "自定义强调色"
+                            title.zh-TW: "自訂強調色"
                             type: variable-text
                             default: ''
                             description: 'Overrides the default accent colour. If left empty, defaults to the preset accent. Accepts any valid CSS colour format (e.g., hex, RGB(A), HSL, OKLCH, var(--interactive-accent)).'
+                            description.zh: "覆盖默认强调色。留空时使用预设。接受有效的 CSS 颜色格式，例如 hex、RGB(A)、HSL、OKLCH 或 var(--interactive-accent)。"
+                            description.zh-TW: "覆蓋預設強調色。留空時使用預設。接受有效的 CSS 顏色格式，例如 hex、RGB(A)、HSL、OKLCH 或 var(--interactive-accent)。"
 
     -
                             id: ssopt-custom-accents-total-enable-dark
                             title: "Enable Fully Custom Accents"
+                            title.zh: "启用完全自定义强调色"
+                            title.zh-TW: "啟用完全自訂強調色"
                             type: class-toggle
                             description: "When enabled, lets you override the secondary and tertiary accent colours (--col-accent-1 and --col-accent-2) using the fields below."
+                            description.zh: "启用后，可通过下方字段覆盖第二、第三强调色（--col-accent-1 和 --col-accent-2）。"
+                            description.zh-TW: "啟用後，可通過下方欄位覆蓋第二、第三強調色（--col-accent-1 和 --col-accent-2）。"
                             default: false
 
     -
                             id: 'color-pax-d-accent-1-textfield'
                             title: "Custom Accent Colour — Secondary"
+                            title.zh: "自定义第二强调色"
+                            title.zh-TW: "自訂第二強調色"
                             type: variable-text
                             default: ''
                             description: "Overrides the default secondary accent colour. If left empty, falls back to the preset. Accepts any valid CSS colour format (e.g., hex, RGB, HSL, OKLCH)."
+                            description.zh: "覆盖默认第二强调色。留空时使用预设。接受有效的 CSS 颜色格式，例如 hex、RGB、HSL 或 OKLCH。"
+                            description.zh-TW: "覆蓋預設第二強調色。留空時使用預設。接受有效的 CSS 顏色格式，例如 hex、RGB、HSL 或 OKLCH。"
 
     -
                             id: 'color-pax-d-accent-2-textfield'
                             title: "Custom Accent Colour — Tertiary"
+                            title.zh: "自定义第三强调色"
+                            title.zh-TW: "自訂第三強調色"
                             type: variable-text
                             default: ''
                             description: "Overrides the default tertiary accent colour. If left empty, falls back to the preset. Accepts any valid CSS colour format (e.g., hex, RGB, HSL, OKLCH)."
+                            description.zh: "覆盖默认第三强调色。留空时使用预设。接受有效的 CSS 颜色格式，例如 hex、RGB、HSL 或 OKLCH。"
+                            description.zh-TW: "覆蓋預設第三強調色。留空時使用預設。接受有效的 CSS 顏色格式，例如 hex、RGB、HSL 或 OKLCH。"
     -
             id: V3-willemstad-color-rainbow-settings-dark
             title: "Rainbow Colours"
+            title.zh: "彩虹色"
+            title.zh-TW: "彩虹色"
             description: "Red, Orange, Yellow, Green, Cyan, Blue, Purple and Pink"
+            description.zh: "红、橙、黄、绿、青、蓝、紫、粉"
+            description.zh-TW: "紅、橙、黃、綠、青、藍、紫、粉"
             type: heading
             level: 3
             collapsed: true
     -
                 id: color-rainbow-d-presets
                 title: "Presets for Rainbow Colours"
+                title.zh: "彩虹色预设"
+                title.zh-TW: "彩虹色預設"
                 type: class-select
                 description: "Presets might not cleanly fit into Obsidian's specific colour palette."
+                description.zh: "预设颜色可能无法完全对应 Obsidian 指定的色彩分类。"
+                description.zh-TW: "預設顏色可能無法完全對應 Obsidian 指定的色彩分類。"
                 allowEmpty: false
                 default: default
                 options:
@@ -45806,74 +46182,120 @@ settings:
     -
                 id: V4-willemstad-color-rainbows-variations-dark
                 title: Custom Settings
+                title.zh: "自定义设置"
+                title.zh-TW: "自訂設定"
                 type: heading
                 level: 4
                 collapsed: true
     -
                 id: ssopt-custom-rainbow-colours-dark
                 title: 'Enable User-Set Rainbow Colours for Dark Mode'
+                title.zh: "启用深色模式自定义彩虹色"
+                title.zh-TW: "啟用深色模式自訂彩虹色"
                 type: class-toggle
                 description: "When enabled, this allows you to override preset rainbow colours with your preferred colours. Rainbow colours not overriden will use the prevailing colour available in the preset."
+                description.zh: "启用后，可覆盖彩虹色预设。未单独覆盖的颜色仍使用当前预设。"
+                description.zh-TW: "啟用後，可覆蓋彩虹色預設。未單獨覆蓋的顏色仍使用當前預設。"
                 default: false
     -
                     id: color-pax-d-red
                     title: 'Custom Colour — Red'
+                    title.zh: "自定义颜色：红色"
+                    title.zh-TW: "自訂顏色：紅色"
                     type: variable-text
                     default: ''
                     description: 'Overrides the default Red colour. If left empty, defaults to the preset colour. Accepts all valid CSS colour values (e.g., hex, RGB, HSL, var(--interactive-accent)).'
+                    description.zh: "覆盖默认红色。留空时使用预设。接受有效的 CSS 颜色值，例如 hex、RGB、HSL 或 var(--interactive-accent)。"
+                    description.zh-TW: "覆蓋預設紅色。留空時使用預設。接受有效的 CSS 顏色值，例如 hex、RGB、HSL 或 var(--interactive-accent)。"
     -
                     id: color-pax-d-orange
                     title: 'Custom Colour — Orange'
+                    title.zh: "自定义颜色：橙色"
+                    title.zh-TW: "自訂顏色：橙色"
                     type: variable-text
                     default: ''
                     description: 'Overrides the default Orange colour. If left empty, defaults to the preset colour. Accepts all valid CSS colour values (e.g., hex, RGB, HSL, var(--interactive-accent)).'
+                    description.zh: "覆盖默认橙色。留空时使用预设。接受有效的 CSS 颜色值，例如 hex、RGB、HSL 或 var(--interactive-accent)。"
+                    description.zh-TW: "覆蓋預設橙色。留空時使用預設。接受有效的 CSS 顏色值，例如 hex、RGB、HSL 或 var(--interactive-accent)。"
     -
                     id: color-pax-d-yellow
                     title: 'Custom Colour — Yellow'
+                    title.zh: "自定义颜色：黄色"
+                    title.zh-TW: "自訂顏色：黃色"
                     type: variable-text
                     default: ''
                     description: 'Overrides the default Yellow colour. If left empty, defaults to the preset colour. Accepts all valid CSS colour values (e.g., hex, RGB, HSL, var(--interactive-accent)).'
+                    description.zh: "覆盖默认黄色。留空时使用预设。接受有效的 CSS 颜色值，例如 hex、RGB、HSL 或 var(--interactive-accent)。"
+                    description.zh-TW: "覆蓋預設黃色。留空時使用預設。接受有效的 CSS 顏色值，例如 hex、RGB、HSL 或 var(--interactive-accent)。"
     -
                     id: color-pax-d-green
                     title: 'Custom Colour — Green'
+                    title.zh: "自定义颜色：绿色"
+                    title.zh-TW: "自訂顏色：綠色"
                     type: variable-text
                     default: ''
                     description: 'Overrides the default Green colour. If left empty, defaults to the preset colour. Accepts all valid CSS colour values (e.g., hex, RGB, HSL, var(--interactive-accent)).'
+                    description.zh: "覆盖默认绿色。留空时使用预设。接受有效的 CSS 颜色值，例如 hex、RGB、HSL 或 var(--interactive-accent)。"
+                    description.zh-TW: "覆蓋預設綠色。留空時使用預設。接受有效的 CSS 顏色值，例如 hex、RGB、HSL 或 var(--interactive-accent)。"
     -
                     id: color-pax-d-cyan
                     title: 'Custom Colour — Cyan'
+                    title.zh: "自定义颜色：青色"
+                    title.zh-TW: "自訂顏色：青色"
                     type: variable-text
                     default: ''
                     description: 'Overrides the default Cyan colour. If left empty, defaults to the preset colour. Accepts all valid CSS colour values (e.g., hex, RGB, HSL, var(--interactive-accent)).'
+                    description.zh: "覆盖默认青色。留空时使用预设。接受有效的 CSS 颜色值，例如 hex、RGB、HSL 或 var(--interactive-accent)。"
+                    description.zh-TW: "覆蓋預設青色。留空時使用預設。接受有效的 CSS 顏色值，例如 hex、RGB、HSL 或 var(--interactive-accent)。"
     -
                     id: color-pax-d-blue
                     title: 'Custom Colour — Blue'
+                    title.zh: "自定义颜色：蓝色"
+                    title.zh-TW: "自訂顏色：藍色"
                     type: variable-text
                     default: ''
                     description: 'Overrides the default Blue colour. If left empty, defaults to the preset colour. Accepts all valid CSS colour values (e.g., hex, RGB, HSL, var(--interactive-accent)).'
+                    description.zh: "覆盖默认蓝色。留空时使用预设。接受有效的 CSS 颜色值，例如 hex、RGB、HSL 或 var(--interactive-accent)。"
+                    description.zh-TW: "覆蓋預設藍色。留空時使用預設。接受有效的 CSS 顏色值，例如 hex、RGB、HSL 或 var(--interactive-accent)。"
     -
                     id: color-pax-d-purple
                     title: 'Custom Colour — Purple'
+                    title.zh: "自定义颜色：紫色"
+                    title.zh-TW: "自訂顏色：紫色"
                     type: variable-text
                     default: ''
                     description: 'Overrides the default Purple colour. If left empty, defaults to the preset colour. Accepts all valid CSS colour values (e.g., hex, RGB, HSL, var(--interactive-accent)).'
+                    description.zh: "覆盖默认紫色。留空时使用预设。接受有效的 CSS 颜色值，例如 hex、RGB、HSL 或 var(--interactive-accent)。"
+                    description.zh-TW: "覆蓋預設紫色。留空時使用預設。接受有效的 CSS 顏色值，例如 hex、RGB、HSL 或 var(--interactive-accent)。"
     -
                     id: color-pax-d-pink
                     title: 'Custom Colour — Pink'
+                    title.zh: "自定义颜色：粉色"
+                    title.zh-TW: "自訂顏色：粉色"
                     type: variable-text
                     default: ''
                     description: 'Overrides the default Pink colour. If left empty, defaults to the preset colour. Accepts all valid CSS colour values (e.g., hex, RGB, HSL, var(--interactive-accent)).'
+                    description.zh: "覆盖默认粉色。留空时使用预设。接受有效的 CSS 颜色值，例如 hex、RGB、HSL 或 var(--interactive-accent)。"
+                    description.zh-TW: "覆蓋預設粉色。留空時使用預設。接受有效的 CSS 顏色值，例如 hex、RGB、HSL 或 var(--interactive-accent)。"
     -
         id: V3-willemstad-color-selection-settings-dark
         title: "--text-selection"
+        title.zh: "文本选区（--text-selection）"
+        title.zh-TW: "文本選區（--text-selection）"
         description: "Text Selection and Highlights"
+        description.zh: "文本选区与高亮"
+        description.zh-TW: "文本選區與高亮"
         type: heading
         level: 3
         collapsed: true
     -
         id: col-selection-d-presets
         title: "Presets for Selection Colour"
+        title.zh: "选区颜色预设"
+        title.zh-TW: "選區顏色預設"
         description: "Choose a color for selected text."
+        description.zh: "选择文本选区的颜色。"
+        description.zh-TW: "選擇文本選區的顏色。"
         type: class-select
         allowEmpty: false
         default: ssopt-sel-d-default-yellow
@@ -45923,60 +46345,94 @@ settings:
     -
         id: V4-willemstad-color-selection-variations-dark
         title: Custom Settings
+        title.zh: "自定义设置"
+        title.zh-TW: "自訂設定"
         type: heading
         level: 4
         collapsed: true
     -
         id: ssopt-custom-selection-colours-dark
         title: 'Enable User-Set Selection Colour for Dark Mode'
+        title.zh: "启用深色模式自定义选区颜色"
+        title.zh-TW: "啟用深色模式自訂選區顏色"
         type: class-toggle
         description: "When enabled, this allows you to override the preset selection colour with your preferred colour. If left empty, it will use the prevailing colour from the selected preset."
+        description.zh: "启用后，可覆盖选区颜色预设。留空时使用当前预设的颜色。"
+        description.zh-TW: "啟用後，可覆蓋選區顏色預設。留空時使用當前預設的顏色。"
         default: false
     -
         id: color-pax-d-selection
         title: 'Custom Selection Colour'
+        title.zh: "自定义选区颜色"
+        title.zh-TW: "自訂選區顏色"
         type: variable-text
         default: ''
         description: 'Overrides the default selection colour. If left empty, defaults to the preset colour. Accepts all valid CSS colour values (e.g., hex, RGB, HSL, var(--interactive-accent)).'
+        description.zh: "覆盖默认选区颜色。留空时使用预设。接受有效的 CSS 颜色值，例如 hex、RGB、HSL 或 var(--interactive-accent)。"
+        description.zh-TW: "覆蓋預設選區顏色。留空時使用預設。接受有效的 CSS 顏色值，例如 hex、RGB、HSL 或 var(--interactive-accent)。"
     -
         id: V3-willemstad-color-contrast-settings-dark
         title: 'Cross-Colour UI (Light UI)'
+        title.zh: "跨模式配色界面（浅色界面）"
+        title.zh-TW: "跨模式配色介面（淺色介面）"
         type: heading
         level: 3
         collapsed: true
     -
         id: ssopt-theme-contrast-dark
         title: Enable Contrast
+        title.zh: "启用对比配色"
+        title.zh-TW: "啟用對比配色"
         type: class-toggle
         description: "When enabled, UI elements like the titlebar, ribbon, status bar, and side panes will use a contrasting colour scheme taken from the current mode's chroma and hue."
+        description.zh: "启用后，标题栏、侧边工具栏、状态栏和侧边面板等界面元素使用由当前模式彩度与色相生成的对比配色。"
+        description.zh-TW: "啟用後，標題列、側邊工具列、狀態列和側邊面板等介面元素使用由當前模式彩度與色相生成的對比配色。"
         default: false
     -
         id: ssopt-tc-cross-d
         title: Use Base Colours from Light Mode
+        title.zh: "使用浅色模式的基础配色"
+        title.zh-TW: "使用淺色模式的基礎配色"
         type: class-toggle
         description: "Imports the base background and text colours from your light mode settings to use for the contrasting UI elements. The base colours within your main editing workspace will not be affected."
+        description.zh: "从浅色模式设置导入背景和文本基础配色，用于对比界面元素。主编辑工作区的基础配色不受影响。"
+        description.zh-TW: "從淺色模式設定匯入背景和文本基礎配色，用於對比介面元素。主編輯工作區的基礎配色不受影響。"
         default: false
     -
         id: ssopt-tc-accent-cross-d
         title: Use Accent Colours from Light Mode
+        title.zh: "使用浅色模式的强调色"
+        title.zh-TW: "使用淺色模式的強調色"
         type: class-toggle
         description: "Imports the accent colours from your light mode settings to use for the contrasting UI elements. The accent colours within your main editing workspace will not be affected."
+        description.zh: "从浅色模式设置导入强调色，用于对比界面元素。主编辑工作区的强调色不受影响。"
+        description.zh-TW: "從淺色模式設定匯入強調色，用於對比介面元素。主編輯工作區的強調色不受影響。"
         default: false
     -
         id: info-override-template-dark
         title: Override via Custom Template Snippet
+        title.zh: "使用自定义模板代码片段覆盖配色"
+        title.zh-TW: "使用自訂模板程式碼片段覆蓋配色"
         type: heading
         level: 3
         collapsed: true
     -
             id: ssopt-custom-colour-template-dark
             title: Enable User-Set Colours via Template for Dark Mode
+            title.zh: "启用深色模式模板自定义配色"
+            title.zh-TW: "啟用深色模式模板自訂配色"
             description: "Enable this option to allow the use of a snippet, for specific preset variables which will customize colors for the theme's appearance in dark mode. This will override the variables set within Style Settings."
+            description.zh: "启用后，可用包含指定预设变量的代码片段自定义深色模式配色。这会覆盖 Style Settings 中设置的变量。"
+            description.zh-TW: "啟用後，可用包含指定預設變數的程式碼片段自訂深色模式配色。這會覆蓋 Style Settings 中設定的變數。"
             type: class-toggle
     -
             id: info-template-file-dark
             title: Template Snippet File
+            title.zh: "模板代码片段文件"
+            title.zh-TW: "模板程式碼片段檔案"
             description: "[Template File](https://willemstad.cc/Dev+Docs/Template+Snippet)"
+            description.zh: "[模板文件](https://willemstad.cc/Dev+Docs/Template+Snippet)"
+            description.zh-TW: "[模板檔案](https://willemstad.cc/Dev+Docs/Template+Snippet)"
             type: info-text
             markdown: true
 */
@@ -45988,31 +46444,47 @@ settings:
     -
         id: startup
         title: Startup Screen
+        title.zh: "启动画面"
+        title.zh-TW: "啟動畫面"
         description: "Options to modify the startup screen."
+        description.zh: "调整启动画面。"
+        description.zh-TW: "調整啟動畫面。"
         type: heading
         level: 2
         collapsed: false
     -
             id: info-startup
             title: Note on Startup Screen Customisations
+            title.zh: "启动画面自定义说明"
+            title.zh-TW: "啟動畫面自訂說明"
             type: class-toggle
             document: DS01-Startup-DefaultN
             description: "Please note as Style Settings loads slightly after the Obsidian startup screen first loads, there will be a slight delay before the customisations take effect."
+            description.zh: "Style Settings 的加载稍晚于 Obsidian 启动画面，因此自定义效果会略有延迟。"
+            description.zh-TW: "Style Settings 的載入稍晚於 Obsidian 啟動畫面，因此自訂效果會略有延遲。"
             default: false
     -
             id: ssopt-startup-default
             title: Revert to Default Startup Screen
+            title.zh: "恢复默认启动画面"
+            title.zh-TW: "恢復預設啟動畫面"
             type: class-toggle
             document: DS01-Startup-DefaultN
             description: "When enabled, this reverts the startup screen to the default Obsidian startup screen."
+            description.zh: "启用后，恢复 Obsidian 默认启动画面。"
+            description.zh-TW: "啟用後，恢復 Obsidian 預設啟動畫面。"
             default: false
     -
             id: startup-obsidian-image
             title: Select Obsidian Startup Icon
+            title.zh: "选择 Obsidian 启动图标"
+            title.zh-TW: "選擇 Obsidian 啟動圖示"
             type: variable-select
             document: DS01-Startup-DefaultN
             notes: (Requires 'Revert to Default Startup Screen' enabled)
             description: "This changes the Obsidian icon displayed on the startup screen. The default is the 3D version of the current logo."
+            description.zh: "更改启动画面中显示的 Obsidian 图标。默认为当前标志的 3D 版本。 选项含义：3D Logo Icon：3D 标志；Current Line Icon：当前线条图标；Current Flat Icon (Default)：当前平面图标（默认）；Previous Line Icon (Gemmy)：旧版线条图标（Gemmy）；Previous Filled Icon (Gemmy)：旧版实心图标（Gemmy）。"
+            description.zh-TW: "更改啟動畫面中顯示的 Obsidian 圖示。預設為當前標誌的 3D 版本。 選項含義：3D Logo Icon：3D 標誌；Current Line Icon：當前線條圖示；Current Flat Icon (Default)：當前平面圖標（預設）；Previous Line Icon (Gemmy)：舊版線條圖示（Gemmy）；Previous Filled Icon (Gemmy)：舊版實心圖示（Gemmy）。"
             allowEmpty: false
             default: var(--logo-icon-filled-flat)
             options:
@@ -46034,25 +46506,37 @@ settings:
     -
         id: titlebar
         title: App Titlebar
+        title.zh: "应用标题栏"
+        title.zh-TW: "應用標題列"
         description: Options to manipulate and control the titlebar.
+        description.zh: "调整标题栏。"
+        description.zh-TW: "調整標題列。"
         type: heading
         level: 2
         collapsed: false
     -
             id: ssopt-titlebar-use-accent
             title: Use Accent Colour for Titlebar
+            title.zh: "标题栏使用强调色"
+            title.zh-TW: "標題列使用強調色"
             type: class-toggle
             document: DA12-AppliedColours
             notes: (For Obsidian Frame and Frameless Mode only)
             description: "When enabled, this changes the titlebar colour to use the accent colours."
+            description.zh: "启用后，标题栏使用强调色。"
+            description.zh-TW: "啟用後，標題列使用強調色。"
             addCommand: true
     -
             id: col-titlebar-accent
             title: Titlebar Accent Colour
+            title.zh: "标题栏强调色"
+            title.zh-TW: "標題列強調色"
             type: variable-select
             document: DA12-AppliedColours
             notes: (For Obsidian Frame and Frameless Mode only; Requires 'Use Accent Colour for Titlebar' enabled)
             description: "Select the specific accent colour to be used for the titlebar here."
+            description.zh: "选择标题栏使用的具体强调色。"
+            description.zh-TW: "選擇標題列使用的具體強調色。"
             allowEmpty: false
             default: var(--color-accent)
             options:
@@ -46068,32 +46552,48 @@ settings:
     -
             id: ssopt-exclude-titlebar-buttons
             title: Disable Titlebar Control Buttons
+            title.zh: "禁用标题栏窗口控制按钮"
+            title.zh-TW: "停用標題列視窗控制按鈕"
             type: class-toggle
             document: AT02-Opt-Titlebar
             notes: (For Windows and Linux, and in Frameless Mode)
             description: "When enabled, the three control buttons (minimise, maximise and close) on the right side of the titlebar will be omitted. Drag the left sidebar to move the Obsidian window around your screen, double-click to minimise/expand, and Alt-F4 (Windows) to close."
+            description.zh: "启用后，隐藏标题栏右侧的最小化、最大化和关闭按钮。可拖动左侧边栏移动窗口，双击缩小或展开，Windows 下可用 Alt-F4 关闭。"
+            description.zh-TW: "啟用後，隱藏標題列右側的最小化、最大化和關閉按鈕。可拖動左側邊欄移動視窗，雙擊縮小或展開，Windows 下可用 Alt-F4 關閉。"
             default: false
             addCommand: true
     -
             id: ssopt-tb-willemstad
             title: Remove Willemstad Version Number Suffix
+            title.zh: "移除 Willemstad 版本号后缀"
+            title.zh-TW: "移除 Willemstad 版本號字尾"
             type: class-toggle
             document: AA01-License
             notes: (For Obsidian Frame Mode only)
             description: "When enabled, the Willemstad version number suffix is removed from the titlebar, from the end of the Obsidian version number."
+            description.zh: "启用后，移除标题栏中 Obsidian 版本号后附加的 Willemstad 版本号。"
+            description.zh-TW: "啟用後，移除標題列中 Obsidian 版本號後附加的 Willemstad 版本號。"
     -
         id: statusbar
         title: Status Bar
+        title.zh: "状态栏"
+        title.zh-TW: "狀態列"
         description: Options to manipulate and control the status bar.
+        description.zh: "调整状态栏。"
+        description.zh-TW: "調整狀態列。"
         type: heading
         level: 2
         collapsed: false
     -
             id: ssopt-status-bar-size
             title: Style of Status Bar
+            title.zh: "状态栏样式"
+            title.zh-TW: "狀態列樣式"
             type: class-select
             document: DV01-StatusBar
             description: Choose the format your status bar should take in Obsidian.
+            description.zh: "选择 Obsidian 状态栏的显示样式。 选项含义：Full：完整；Mini (Default Obsidian)：迷你（Obsidian 默认）。"
+            description.zh-TW: "選擇 Obsidian 狀態列的顯示樣式。 選項含義：Full：完整；Mini (Default Obsidian)：迷你（Obsidian 預設）。"
             allowEmpty: false
             default: default
             options:
@@ -46109,10 +46609,14 @@ settings:
     -
             id: status-bar-full-justify-content
             title: Content Justification in Full Status Bar
+            title.zh: "完整状态栏内容对齐方式"
+            title.zh-TW: "完整狀態列內容對齊方式"
             type: variable-select
             document: DV01-StatusBar
             note: (Requires 'Style of Status Bar' set to 'Full')
             description: Choose the justification of the content in the full-sized status bar. The default option is right-aligned.
+            description.zh: "选择完整状态栏的内容对齐方式，默认为右对齐。 选项含义：Left-Aligned：左对齐；Centre-Aligned：居中；Right-Aligned：右对齐。"
+            description.zh-TW: "選擇完整狀態列的內容對齊方式，預設為右對齊。 選項含義：Left-Aligned：左對齊；Centre-Aligned：居中；Right-Aligned：右對齊。"
             default: right
             options:
                 -
@@ -46127,10 +46631,14 @@ settings:
     -
             id: status-bar-align
             title: Alignment of Mini Status Bar
+            title.zh: "迷你状态栏对齐方式"
+            title.zh-TW: "迷你狀態列對齊方式"
             type: class-select
             document: DV01-StatusBar
             note: (Requires 'Style of Status Bar' set to 'Mini')
             description: Choose the position and alignment you would like to use for the mini-sized status bar in Obsidian.
+            description.zh: "选择 Obsidian 迷你状态栏的位置与对齐方式。 选项含义：Centre-Aligned (Default Willemstad)：居中（Willemstad 默认）；Right-Aligned (Default Obsidian)：右对齐（Obsidian 默认）。"
+            description.zh-TW: "選擇 Obsidian 迷你狀態列的位置與對齊方式。 選項含義：Centre-Aligned (Default Willemstad)：居中（Willemstad 預設）；Right-Aligned (Default Obsidian)：右對齊（Obsidian 預設）。"
             allowEmpty: false
             default: default
             options:
@@ -46143,8 +46651,12 @@ settings:
     -
             id: ssopt-status-bar-full-style
             title: Coverage of Full Status Bar
+            title.zh: "完整状态栏覆盖范围"
+            title.zh-TW: "完整狀態列覆蓋範圍"
             type: variable-select
             description: "Determine whether the Full Status Bar should be full-width, or whether the ribbon should be full-height."
+            description.zh: "决定完整状态栏是否占满整个窗口宽度，或让侧边工具栏占满窗口高度。 选项含义：Stylised (excludes space under left ribbon)：不覆盖左侧工具栏下方；Full-Width (including space under left ribbon)：全宽（包含左侧工具栏下方）。"
+            description.zh-TW: "決定完整狀態列是否佔滿整個視窗寬度，或讓側邊工具列佔滿視窗高度。 選項含義：Stylised (excludes space under left ribbon)：不覆蓋左側工具列下方；Full-Width (including space under left ribbon)：全寬（包含左側工具列下方）。"
             note: (Requires 'Style of Status Bar' set to 'Full')
             allowEmpty: false
             default: '1'
@@ -46158,18 +46670,26 @@ settings:
     -
             id: ssopt-status-bar-float-not
             title: Disable Floating Status Bar
+            title.zh: "禁用悬浮状态栏"
+            title.zh-TW: "停用懸浮狀態列"
             type: class-toggle
             document: DV01-StatusBar
             note: (Requites 'Style of Status Bar' set to 'Mini')
             description: "By default, the status bar will float away from the bottom edge of the application. This option allows you to anchor the status bar to the bottom of the screen."
+            description.zh: "状态栏默认悬浮在应用底边上方。启用此项可将状态栏固定到窗口底部。"
+            description.zh-TW: "狀態列預設懸浮在應用底邊上方。啟用此項可將狀態列固定到視窗底部。"
             default: false
     -
             id: status-bar-bottom-float-margin
             title: Floating Bar Distance from Bottom
+            title.zh: "悬浮状态栏距底部的距离"
+            title.zh-TW: "懸浮狀態列距底部的距離"
             type: variable-number-slider
             document: DV01-StatusBar
             notes: (Requires 'Floating Status Bar' enabled)
             description: "Controls how far the floating status bar is from the bottom edge of the screen. The default value is 8px."
+            description.zh: "控制悬浮状态栏与窗口底边的距离。默认为 8px。"
+            description.zh-TW: "控制懸浮狀態列與視窗底邊的距離。預設為 8px。"
             format: 'px'
             default: 8
             min: 1
@@ -46178,26 +46698,38 @@ settings:
     -
             id: ssopt-status-bar-shift-workspace
             title: Account for Status Bar in Workspace
+            title.zh: "在工作区为状态栏预留空间"
+            title.zh-TW: "在工作區為狀態列預留空間"
             type: class-toggle
             document: DV01-StatusBar
             note: (Requires 'Style of Status Bar' set to 'Mini')
             description: "By default, Willemstad does not account for space required for the mini status bar in the workspace. When this option is enabled, additional padding will be added to selected workspace elements to account for the status bar."
+            description.zh: "Willemstad 默认不在工作区为迷你状态栏预留空间。启用后，为相关工作区元素增加内边距，给状态栏留出空间。"
+            description.zh-TW: "Willemstad 預設不在工作區為迷你狀態列預留空間。啟用後，為相關工作區元素增加內邊距，給狀態列留出空間。"
             default: false
     -
             id: ssopt-status-bar-glass
             title: Frosted Glass Aesthetic
+            title.zh: "毛玻璃效果"
+            title.zh-TW: "毛玻璃效果"
             type: class-toggle
             document: DV01-StatusBar
             notes: (Requires 'No Blur Backdrop Filter' deactivated) 
             description: "When enabled, the status bar will adopt a frosted glass aesthetic."
+            description.zh: "启用后，状态栏采用毛玻璃效果。"
+            description.zh-TW: "啟用後，狀態列採用毛玻璃效果。"
             default: false
     -
             id: status-bar-glass-blur
             title: Blur Intensity of Frosted Glass Aesthetic
+            title.zh: "毛玻璃效果模糊强度"
+            title.zh-TW: "毛玻璃效果模糊強度"
             type: variable-number-slider
             document: DV01-StatusBar
             notes: (Requires 'Frosted Glass Aesthetic' enabled) 
             description: "Change the amount of blur/frost applied to the status bar. The original settings is 4px."
+            description.zh: "调整状态栏的模糊程度。默认值为 4px。"
+            description.zh-TW: "調整狀態列的模糊程度。預設值為 4px。"
             format: px
             default: 4
             min: 0
@@ -46206,10 +46738,14 @@ settings:
     -
             id: status-bar-max-width
             title: Max Width of Status Bar
+            title.zh: "状态栏最大宽度"
+            title.zh-TW: "狀態列最大寬度"
             type: variable-number-slider
             document: DV01-StatusBar
             note: (Requires 'Style of Status Bar' set to 'Mini')
             description: "Change the maximum width of the status bar. The original settings is 85%."
+            description.zh: "调整状态栏最大宽度。默认值为 85%。"
+            description.zh-TW: "調整狀態列最大寬度。預設值為 85%。"
             format: '%'
             default: 85
             min: 20
@@ -46218,20 +46754,30 @@ settings:
     -
             id: ssopt-status-bar-borderless
             title: Borderless Status Bar
+            title.zh: "状态栏无边框"
+            title.zh-TW: "狀態列無邊框"
             type: class-toggle
             document: DV01-StatusBar
             description: "When enabled, the status bar will have no borders applied to it."
+            description.zh: "启用后，移除状态栏边框。"
+            description.zh-TW: "啟用後，移除狀態列邊框。"
             default: false
     -
         id: ribbon-mwb-settings
         title: Ribbon and Main Workspace Buttons
+        title.zh: "侧边工具栏与主工作区按钮"
+        title.zh-TW: "側邊工具列與主工作區按鈕"
         description: Options to manipulate and control the general Obsidian app interface.
+        description.zh: "调整 Obsidian 应用界面。"
+        description.zh-TW: "調整 Obsidian 應用介面。"
         type: heading
         level: 2
         collapsed: false
     -
             id: ribbon
             title: Ribbon
+            title.zh: "侧边工具栏"
+            title.zh-TW: "側邊工具列"
             description:
             type: heading
             level: 3
@@ -46239,9 +46785,13 @@ settings:
     -
                 id: ribbon-select
                 title: Ribbon Style
+                title.zh: "侧边工具栏样式"
+                title.zh-TW: "側邊工具列樣式"
                 type: class-select
                 document: DC01A-Opt-Ribbon-Float, DC01B-Opt-Ribbon-No
                 description: Choose which ribbon/sidebar/side docks style you would like to use for Obsidian.
+                description.zh: "选择 Obsidian 的侧边工具栏、侧边栏与侧边面板样式。 选项含义：Default Ribbon：默认工具栏；Floating Ribbon：悬浮工具栏。"
+                description.zh-TW: "選擇 Obsidian 的側邊工具列、側邊欄與側邊面板樣式。 選項含義：Default Ribbon：預設工具列；Floating Ribbon：懸浮工具列。"
                 allowEmpty: false
                 default: default
                 options:
@@ -46257,18 +46807,26 @@ settings:
     -
                 id: ssopt-ribbon-no-drag
                 title: Disable Draggable Ribbon
+                title.zh: "禁用侧边工具栏拖动"
+                title.zh-TW: "停用側邊工具列拖動"
                 type: class-toggle
                 document: DA02-FirstOrder (DA02-2 | SR Side Dock Ribbon)
                 notes: (Disabled by default in Floating Ribbon Mode for usability reasons)
                 description: "Willemstad sets the ribbon as draggable by default. This option allows the user to disable this feature."
+                description.zh: "Willemstad 默认允许拖动侧边工具栏来移动窗口。此项可禁用该功能。"
+                description.zh-TW: "Willemstad 預設允許拖動側邊工具列來移動視窗。此項可停用該功能。"
                 default: false
     -
                     id: height-norm-sd
                     title: 'Floating Ribbon Height, when not hovered'
+                    title.zh: "悬浮工具栏高度（未悬停）"
+                    title.zh-TW: "懸浮工具列高度（未懸停）"
                     type: variable-number-slider
                     document: DC01A-Opt-Ribbon-Float
                     notes: (Requires 'Floating Ribbon' ribbon style enabled)
                     description: 'Set the height of the tabs for the Floating Ribbon, when not hovered.'
+                    description.zh: "设置悬浮工具栏在未悬停时的标签高度。"
+                    description.zh-TW: "設定懸浮工具列在未懸停時的標籤高度。"
                     format: '%'
                     default: 25
                     min: 5
@@ -46277,10 +46835,14 @@ settings:
     -
                     id: height-hover-sd
                     title: 'Floating Ribbon Height, when hovered'
+                    title.zh: "悬浮工具栏高度（悬停时）"
+                    title.zh-TW: "懸浮工具列高度（懸停時）"
                     type: variable-number-slider
                     document: DC01A-Opt-Ribbon-Float
                     notes: (Requires 'Floating Ribbon' ribbon style enabled)
                     description: 'Set the height of the tabs for the Floating Ribbon, when hovered.'
+                    description.zh: "设置悬浮工具栏在悬停时的标签高度。"
+                    description.zh-TW: "設定懸浮工具列在懸停時的標籤高度。"
                     format: '%'
                     default: 50
                     min: 5
@@ -46289,25 +46851,37 @@ settings:
     -
                     id: info-width-norm-sd
                     title: Note on Floating Ribbon Width
+                    title.zh: "悬浮工具栏宽度说明"
+                    title.zh-TW: "懸浮工具列寬度說明"
                     type: class-toggle
                     document: DC01A-Opt-Ribbon-Float
                     description: As the width of the floating ribbon is set via the original ribbon width, this is not controllable by its own. However, this can be changed via the icon sizes, paddings, and margins controls available below in Main Workspace Buttons.
+                    description.zh: "悬浮工具栏的宽度沿用原始工具栏宽度，无法单独调整。可通过下方“主工作区按钮”的图标尺寸、内边距和外边距设置间接调整。"
+                    description.zh-TW: "懸浮工具列的寬度沿用原始工具列寬度，無法單獨調整。可通過下方“主工作區按鈕”的圖示尺寸、內邊距和外邊距設定間接調整。"
                     default: false
     -
                 id: ssopt-sd-float-ribbon-blur
                 title: Enable Blur for Floating Ribbon
+                title.zh: "启用悬浮工具栏模糊效果"
+                title.zh-TW: "啟用懸浮工具列模糊效果"
                 type: class-toggle
                 document: DC01A-Opt-Ribbon-Float
                 notes: (Requires 'Floating Ribbon' ribbon style enabled)
                 description: "Willemstad sets the ribbon as draggable by default. This option allows the user to disable this feature."
+                description.zh: "Willemstad 默认允许拖动侧边工具栏来移动窗口。此项可禁用该功能。"
+                description.zh-TW: "Willemstad 預設允許拖動側邊工具列來移動視窗。此項可停用該功能。"
                 default: false
     -
                 id: blur-floating-ribbon
                 title: Blur Intensity of Floating Ribbon
+                title.zh: "悬浮工具栏模糊强度"
+                title.zh-TW: "懸浮工具列模糊強度"
                 type: variable-select
                 document: DC01A-Opt-Ribbon-Float
                 notes: (Requires 'Enable Blur for Floating Ribbon' enabled; Requires 'Floating Ribbon' ribbon style enabled;                 Requires 'No Blur Backdrop Filter' deactivated)
                 description: "This option allows one to adjust the blur intensity of the floating ribbon."
+                description.zh: "调整悬浮工具栏的模糊强度。"
+                description.zh-TW: "調整懸浮工具列的模糊強度。"
                 default: var(--blur-4)
                 options:
                     -
@@ -46325,6 +46899,8 @@ settings:
     -
             id: mwb-settings
             title: Main Workspace Buttons
+            title.zh: "主工作区按钮"
+            title.zh-TW: "主工作區按鈕"
             description:
             type: heading
             level: 3
@@ -46332,16 +46908,24 @@ settings:
     -
                 id: ssopt-sidebar-toggle-button-no-colour
                 title: Disable Colour of Sidebar Toggle Buttons
+                title.zh: "禁用侧边栏切换按钮的配色"
+                title.zh-TW: "停用側邊欄切換按鈕的配色"
                 type: class-toggle
                 document: DA12-AppliedColours (DA12-3)
                 description: "By default, Willemstad sets the sidebar toggle buttons to be coloured when the sidebars are expanded. This option allows the user to disable this feature."
+                description.zh: "Willemstad 默认在侧边栏展开时为其切换按钮着色。此项可禁用该效果。"
+                description.zh-TW: "Willemstad 預設在側邊欄展開時為其切換按鈕著色。此項可停用該效果。"
                 default: false
     -
                 id: icon-width-sidebar
                 title: Change Width of Rectangle in Opened Sidebar Toggle Buttons
+                title.zh: "调整侧边栏展开时切换按钮中矩形的宽度"
+                title.zh-TW: "調整側邊欄展開時切換按鈕中矩形的寬度"
                 type: variable-number-slider
                 document: DA02-FirstOrder | SB
                 description: "Change how expanded the centre window should be on the sidebar toggle buttons. The original settings are 24%."
+                description.zh: "调整侧边栏切换按钮中央矩形的展开宽度。默认值为 24%。"
+                description.zh-TW: "調整側邊欄切換按鈕中央矩形的展開寬度。預設值為 24%。"
                 format: '%'
                 default: 24
                 min: 10
@@ -46350,23 +46934,35 @@ settings:
     -
                 id: info-ribbon-width-header-height
                 title: Note on Ribbon Width and Header Height
+                title.zh: "侧边工具栏宽度与顶部栏高度说明"
+                title.zh-TW: "側邊工具列寬度與頂部欄高度說明"
                 type: class-toggle
                 document: DA02-FirstOrder
                 description: "Willemstad controls both the ribbon width and the header height via the icon sizes, paddings, and margins controls available below. As such, the ribbon width and header heights are not directly controllable here." 
+                description.zh: "Willemstad 根据下方图标尺寸、内边距和外边距计算侧边工具栏宽度与顶部栏高度，因此这两个尺寸无法在此直接设置。"
+                description.zh-TW: "Willemstad 根據下方圖示尺寸、內邊距和外邊距計算側邊工具列寬度與頂部欄高度，因此這兩個尺寸無法在此直接設定。"
                 default: false
     -
                 id: info-icon-sizes
                 title: Note on Icon Sizes
+                title.zh: "图标尺寸说明"
+                title.zh-TW: "圖示尺寸說明"
                 type: class-toggle
                 document: DA02-FirstOrder
                 description: "Willemstad uses complex math to control icon sizes, paddings, and margin throughout the app interface. You are recommended to stick to the suggested icon and padding sizes, and to use Ctrl (Windows and Linux) or Cmd ⌘ (Mac) + Plus/Minus-key (+/-) to zoom in/out."  
+                description.zh: "Willemstad 通过计算统一控制界面图标尺寸及内外边距。建议采用推荐尺寸，并使用 Ctrl（Windows 和 Linux）或 Cmd（Mac）配合加号或减号（+/-）缩放界面。"
+                description.zh-TW: "Willemstad 通過計算統一控制介面圖示尺寸及內外邊距。建議採用推薦尺寸，並使用 Ctrl（Windows 和 Linux）或 Cmd（Mac）配合加號或減號（+/-）縮放介面。"
                 default: false    
     -
                 id: sidebar-icon-size
                 title: Icon Size — Sidebar Toggle Buttons
+                title.zh: "图标尺寸：侧边栏切换按钮"
+                title.zh-TW: "圖示尺寸：側邊欄切換按鈕"
                 type: variable-number-slider
                 document: DA02-FirstOrder
                 description: "The original settings are 18px."
+                description.zh: "默认值为 18px。"
+                description.zh-TW: "預設值為 18px。"
                 format: px
                 default: 18
                 min: 10
@@ -46375,9 +46971,13 @@ settings:
     -
                 id: header-icon-size
                 title: Icon Size — Header Buttons
+                title.zh: "图标尺寸：顶部栏按钮"
+                title.zh-TW: "圖示尺寸：頂部欄按鈕"
                 type: variable-number-slider
                 document: DA02-FirstOrder
                 description: "The original settings are 16px."
+                description.zh: "默认值为 16px。"
+                description.zh-TW: "預設值為 16px。"
                 format: px
                 default: 16
                 min: 10
@@ -46386,9 +46986,13 @@ settings:
     -
                 id: tab-icon-size
                 title: Icon Size — Tab Buttons
+                title.zh: "图标尺寸：标签页按钮"
+                title.zh-TW: "圖示尺寸：標籤頁按鈕"
                 type: variable-number-slider
                 document: DA02-FirstOrder
                 description: "The original settings are 14px."
+                description.zh: "默认值为 14px。"
+                description.zh-TW: "預設值為 14px。"
                 format: px
                 default: 14
                 min: 10
@@ -46397,9 +47001,13 @@ settings:
     -
                 id: header-padding
                 title: Padding — Header Buttons
+                title.zh: "内边距：顶部栏按钮"
+                title.zh-TW: "內邊距：頂部欄按鈕"
                 type: variable-number-slider
                 document: DA02-FirstOrder
                 description: "The original settings are 6px. Math calculations sets the padding of tab and header buttons from this value."
+                description.zh: "默认值为 6px。标签页与顶部栏按钮的内边距由此值计算得出。"
+                description.zh-TW: "預設值為 6px。標籤頁與頂部欄按鈕的內邊距由此值計算得出。"
                 format: px
                 default: 6
                 min: 0
@@ -46408,9 +47016,13 @@ settings:
     -
                 id: header-margin
                 title: Margin
+                title.zh: "外边距"
+                title.zh-TW: "外邊距"
                 type: variable-number-slider
                 document: DA02-FirstOrder
                 description: "This sets many margin values in the UI, and works because of math magic. The original settings are 4px."
+                description.zh: "此值用于计算界面中多处外边距。默认值为 4px。"
+                description.zh-TW: "此值用於計算介面中多處外邊距。預設值為 4px。"
                 format: px
                 default: 4
                 min: 0
@@ -46419,9 +47031,13 @@ settings:
     -
                 id: hover-frac
                 title: Hover Fraction for Buttons
+                title.zh: "按钮悬停时的放大比例"
+                title.zh-TW: "按鈕懸停時的放大比例"
                 type: variable-number-slider
                 document: DA02-FirstOrder
                 description: "Set the magnitude in which the icons in the ribbon and main workspace buttons should increase in size when hovered over, with respect to the total button space. The default value is 0.25."
+                description.zh: "设置鼠标悬停时，侧边工具栏和主工作区按钮中的图标相对于按钮总空间的放大比例。默认为 0.25。"
+                description.zh-TW: "設定滑鼠懸停時，側邊工具列和主工作區按鈕中的圖示相對於按鈕總空間的放大比例。預設為 0.25。"
                 default: 0.25
                 min: 0
                 max: 1
@@ -46429,15 +47045,23 @@ settings:
     -
         id: vault-profile-settings
         title: Vault Profile
+        title.zh: "仓库信息面板"
+        title.zh-TW: "倉庫資訊面板"
         type: heading
         description: "Options to control the vault profile drawer at the bottom of the left sidebar."
+        description.zh: "调整左侧边栏底部的仓库信息面板。"
+        description.zh-TW: "調整左側邊欄底部的倉庫資訊面板。"
         level: 2
         collapsed: false
     -
         id: ssopt-drawer-bg
         title: Vault Profile Background Colour
+        title.zh: "仓库信息面板背景色"
+        title.zh-TW: "倉庫資訊面板背景色"
         type: variable-select
         description: "Changes the background colour of the vault profile drawer."
+        description.zh: "更改仓库信息面板的背景色。 选项含义：background-secondary (Default)：次背景（默认）；background-primary-alt (Flushes with Left Sidepane)：主背景变体（与左面板一致）。"
+        description.zh-TW: "更改倉庫資訊面板的背景色。 選項含義：background-secondary (Default)：次背景（預設）；background-primary-alt (Flushes with Left Sidepane)：主背景變體（與左面板一致）。"
         allowEmpty: false
         default: '0'
         options:
@@ -46450,23 +47074,35 @@ settings:
     -
         id: editor-workspace-tab-settings
         title: Tabs in Editor Workspace
+        title.zh: "编辑器工作区标签页"
+        title.zh-TW: "編輯器工作區標籤頁"
         description: Options to manipulate and control the tabs in the editor workspace tab headers.
+        description.zh: "调整编辑器工作区顶部的标签页。"
+        description.zh-TW: "調整編輯器工作區頂部的標籤頁。"
         type: heading
         level: 2
         collapsed: false
     -
             id: ssopt-no-pin-tab-front
             title: Disable Pinning Tabs to Front
+            title.zh: "禁用固定标签页置前"
+            title.zh-TW: "停用固定標籤頁置前"
             type: class-toggle
             document: DA01-FirefoxTabs
             description: "By default, pinned tabs in Willemstad are pinned to the front. This option allows one to disable this feature."
+            description.zh: "Willemstad 默认将固定标签页排到最前。此项可禁用该行为。"
+            description.zh-TW: "Willemstad 預設將固定標籤頁排到最前。此項可停用該行為。"
             default: false
     -
             id: workspace-tabs-style-select
             title: Tab Style
+            title.zh: "标签页样式"
+            title.zh-TW: "標籤頁樣式"
             type: class-select
             document: DA02-OtherTabs
             description: 'Choose the visual style for the main editor tabs.'
+            description.zh: "选择主编辑器标签页的视觉样式。 选项含义：Modern (Default)：现代（默认）；Square：方形；Underline：下划线；Box Index：方框索引；Classic Index：经典索引。"
+            description.zh-TW: "選擇主編輯器標籤頁的視覺樣式。 選項含義：Modern (Default)：現代（預設）；Square：方形；Underline：底線；Box Index：方框索引；Classic Index：經典索引。"
             allowEmpty: false
             default: default
             options:
@@ -46488,23 +47124,35 @@ settings:
     -
             id: ssopt-tabs-modern-borderless
             title: Borderless Active Tabs
+            title.zh: "活动标签页无边框"
+            title.zh-TW: "活動標籤頁無邊框"
             type: class-toggle
             document: DA01-FirefoxTabs
             description: "By default, Willemstad's modern tabs have a border around active modern tabs. This option allows one to disable this feature."
+            description.zh: "Willemstad 默认给现代样式的活动标签页添加边框。此项可移除边框。"
+            description.zh-TW: "Willemstad 預設給現代樣式的活動標籤頁新增邊框。此項可移除邊框。"
             default: false
     -
         id: file-explorer-settings
         title: File Explorer
+        title.zh: "文件列表"
+        title.zh-TW: "檔案列表"
         type: heading
         description: 'Options to manipulate and control the file explorer/navigation sidepane.'
+        description.zh: "调整文件列表与导航侧边面板。"
+        description.zh-TW: "調整檔案列表與導航側邊面板。"
         level: 2
         collapsed: false
     -
             id: nav-title-margin
             title: Spacing between Titles in File Explorer
+            title.zh: "文件列表标题间距"
+            title.zh-TW: "檔案列表標題間距"
             type: variable-number-slider
             document: DV01-StatusBar
             description: "Adjusts the vertical spacing between navigation titles. The default is 2px."
+            description.zh: "调整导航标题之间的垂直间距。默认为 2px。"
+            description.zh-TW: "調整導航標題之間的垂直間距。預設為 2px。"
             format: px
             default: 2
             min: 0
@@ -46513,8 +47161,12 @@ settings:
     -
             id: nav-item-white-space
             title: File and Folder Title Wrapping
+            title.zh: "文件与文件夹名称换行"
+            title.zh-TW: "檔案與資料夾名稱換行"
             type: variable-select
             description: "Controls how file and folder names wrap in the navigation pane. 'No Wrap (pre)' is the default Obsidian behavior."
+            description.zh: "控制导航面板中文件和文件夹名称的换行方式。No Wrap (pre) 表示不换行，也是 Obsidian 的默认行为。 选项含义：No Wrap (pre)：不换行；Wrap When Needed (pre-wrap)：按需换行。"
+            description.zh-TW: "控制導航面板中檔案和資料夾名稱的換行方式。No Wrap (pre) 表示不換行，也是 Obsidian 的預設行為。 選項含義：No Wrap (pre)：不換行；Wrap When Needed (pre-wrap)：按需換行。"
             allowEmpty: false
             default: 'pre'
             options:
@@ -46527,27 +47179,43 @@ settings:
     -
             id: ssopt-sticky-nav-folder-title
             title: Sticky Folder Titles
+            title.zh: "文件夹名称吸顶"
+            title.zh-TW: "資料夾名稱吸頂"
             type: class-toggle
             description: "When enabled, folder titles in the File Explorer will stick to the top of the pane as you scroll."
+            description.zh: "启用后，滚动文件列表时，文件夹名称固定在面板顶部。"
+            description.zh-TW: "啟用後，滾動檔案列表時，資料夾名稱固定在面板頂部。"
             default: false
     -
             id: ssopt-disable-nav-icons
             title: Disable Custom File Extension Icons in File Explorer
+            title.zh: "禁用文件列表的自定义扩展名图标"
+            title.zh-TW: "停用檔案列表的自訂副檔名圖示"
             type: class-toggle
             document: X102
             description: "Willemstad changes the file extension text in the file explorer to icons. Toggle this to disable the change and revert back to the Obsidian default."
+            description.zh: "Willemstad 将文件列表中的扩展名文本替换为图标。启用此项可恢复 Obsidian 默认显示方式。"
+            description.zh-TW: "Willemstad 將檔案列表中的副檔名文本替換為圖示。啟用此項可恢復 Obsidian 預設顯示方式。"
     -
         id: nav-header-settings
         title: Navigation Header
+        title.zh: "导航栏"
+        title.zh-TW: "導航欄"
         type: heading
         description: 'Options to manipulate and control items within the navigation header, which is generally located at the top of panes such as File Explorer and Bookmarks.'
+        description.zh: "调整文件列表、书签等面板顶部的导航栏。"
+        description.zh-TW: "調整檔案列表、書籤等面板頂部的導航欄。"
         level: 2
         collapsed: false
     -
             id: ssopt-nav-align
             title: "Alignment of Nav Buttons"
+            title.zh: "导航按钮对齐方式"
+            title.zh-TW: "導航按鈕對齊方式"
             type: variable-select
             description: "Controls the alignment of the buttons (e.g., New Note, New Folder) in the navigation header."
+            description.zh: "控制导航栏中新建笔记、新建文件夹等按钮的对齐方式。 选项含义：Left (Default)：左对齐（默认）；Center：居中；Right：右；Stretch：拉伸。"
+            description.zh-TW: "控制導航欄中新建筆記、新建資料夾等按鈕的對齊方式。 選項含義：Left (Default)：左對齊（預設）；Center：居中；Right：右；Stretch：拉伸。"
             allowEmpty: false
             default: 'left'
             options:
@@ -46566,22 +47234,34 @@ settings:
     -
         id: modals
         title: Modals
+        title.zh: "对话框"
+        title.zh-TW: "對話方塊"
         type: heading
         description: 'Change the widths and heights of modals (the settings/community plugins/themes/Publish menus).'
+        description.zh: "调整设置、社区插件、主题和 Publish 对话框的宽度与高度。"
+        description.zh-TW: "調整設定、社群外掛、主題和 Publish 對話方塊的寬度與高度。"
         level: 2
         collapsed: false
     -
             id: ssopt-revert-mod-community
             title: Revert Community Modals to Default
+            title.zh: "恢复社区插件和主题商店的默认布局"
+            title.zh-TW: "恢復社群外掛和主題商店的預設佈局"
             type: class-toggle
             description: "When enabled, this disables the theme's custom layout for the Community Plugin and Theme store modals, reverting them to the standard Obsidian appearance."
+            description.zh: "启用后，停用主题为社区插件和主题商店提供的自定义布局，恢复 Obsidian 标准外观。"
+            description.zh-TW: "啟用後，停用主題為社群外掛和主題商店提供的自訂佈局，恢復 Obsidian 標準外觀。"
             default: false
     -
             id: grid-columns-container-comm-modal
             title: Community Modals Container Readme Per-Row Items 
+            title.zh: "商店详情页每行操作按钮数"
+            title.zh-TW: "商店詳情頁每行操作按鈕數"
             type: variable-number-slider
             document: MA02-CommWideFixes
             description: "In the Readme for Plugins and Themes in their respective stores, there are buttons to, for example, disable and uninstall the plugin/theme. This option allows one to adjust how many items should appear per row. The original settings are 5 columns."
+            description.zh: "插件或主题商店详情页包含禁用、卸载等操作按钮。此项设置每行显示的按钮数量，默认为 5 列。"
+            description.zh-TW: "外掛或主題商店詳情頁包含停用、解除安裝等操作按鈕。此項設定每行顯示的按鈕數量，預設為 5 列。"
             format: ''
             default: 5
             min: 1
@@ -46589,6 +47269,8 @@ settings:
     -
             id: settings-modal
             title: Settings Modal
+            title.zh: "设置对话框"
+            title.zh-TW: "設定對話方塊"
             type: heading
             description:
             level: 3
@@ -46596,18 +47278,28 @@ settings:
     -
                 id: mod-settings-left-column-spacing
                 title: 'Spacing between Settings Left Column Navigation Items'
+                title.zh: "设置左侧导航分组间距"
+                title.zh-TW: "設定左側導航分組間距"
                 type: variable-text
                 default: '0px'
                 description: "Adjusts the spacing of the settings left column sections, in between 'Options', 'Core Plugins' and 'Community Plugins' segments. Accepts any valid CSS unit (px, em, rem, %, etc.)."
+                description.zh: "调整设置左侧导航中“选项”“核心插件”“社区插件”等分组的间距。接受有效的 CSS 单位，如 px、em、rem 或 %。"
+                description.zh-TW: "調整設定左側導航中“選項”“核心外掛”“社群外掛”等分組的間距。接受有效的 CSS 單位，如 px、em、rem 或 %。"
     -
                 id: ssopt-add-mod-settings-left-column-border
                 title: "Add Border for Settings Left Column Navigation Items"
+                title.zh: "为设置左侧导航分组添加边框"
+                title.zh-TW: "為設定左側導航分組新增邊框"
                 type: class-toggle
                 description: "Adds a bottom border to the settings left column section titles (Options, Core Plugins, Community Plugins)."
+                description.zh: "为设置左侧导航的分组标题（选项、核心插件、社区插件）添加底边框。"
+                description.zh-TW: "為設定左側導航的分組標題（選項、核心外掛、社群外掛）新增底邊框。"
                 default: false
     -
             id: modal-widths
             title: Modal Widths
+            title.zh: "对话框宽度"
+            title.zh-TW: "對話方塊寬度"
             type: heading
             description:
             level: 3
@@ -46615,6 +47307,8 @@ settings:
     -
                 id: modal-width-settings
                 title: Modal Widths — Settings
+                title.zh: "对话框宽度：设置"
+                title.zh-TW: "對話方塊寬度：設定"
                 type: variable-number-slider
                 document: MA11-ModalSizingControls
                 format: 'vw'
@@ -46625,6 +47319,8 @@ settings:
     -
                 id: modal-width-community-plugin
                 title: Modal Widths — Community Plugin Store
+                title.zh: "对话框宽度：社区插件商店"
+                title.zh-TW: "對話方塊寬度：社群外掛商店"
                 type: variable-number-slider
                 document: MA11-ModalSizingControls
                 format: 'vw'
@@ -46635,6 +47331,8 @@ settings:
     -
                 id: modal-width-community-theme
                 title: Modal Widths — Community Theme Store
+                title.zh: "对话框宽度：社区主题商店"
+                title.zh-TW: "對話方塊寬度：社群主題商店"
                 type: variable-number-slider
                 document: MA11-ModalSizingControls
                 format: 'vw'
@@ -46645,6 +47343,8 @@ settings:
     -
                 id: modal-width-publish
                 title: Modal Widths — Publish
+                title.zh: "对话框宽度：Publish"
+                title.zh-TW: "對話方塊寬度：Publish"
                 type: variable-number-slider
                 document: PB005-Publish
                 format: 'vw'
@@ -46655,6 +47355,8 @@ settings:
     -
             id: modal-heights
             title: Modal Heights
+            title.zh: "对话框高度"
+            title.zh-TW: "對話方塊高度"
             type: heading
             document: MA11-ModalSizingControls
             description:
@@ -46663,6 +47365,8 @@ settings:
     -
                 id: modal-height-settings
                 title: Modal Heights — Settings
+                title.zh: "对话框高度：设置"
+                title.zh-TW: "對話方塊高度：設定"
                 type: variable-number-slider
                 document: MA11-ModalSizingControls
                 format: 'vh'
@@ -46673,6 +47377,8 @@ settings:
     -
                 id: modal-height-community-plugin
                 title: Modal Heights — Community Plugin Store
+                title.zh: "对话框高度：社区插件商店"
+                title.zh-TW: "對話方塊高度：社群外掛商店"
                 type: variable-number-slider
                 document: MA11-ModalSizingControls
                 format: 'vh'
@@ -46683,6 +47389,8 @@ settings:
     -
                 id: modal-height-community-theme
                 title: Modal Heights — Community Theme Store
+                title.zh: "对话框高度：社区主题商店"
+                title.zh-TW: "對話方塊高度：社群主題商店"
                 type: variable-number-slider
                 document: MA11-ModalSizingControls
                 format: 'vh'
@@ -46693,6 +47401,8 @@ settings:
     -
                 id: modal-height-publish
                 title: Modal Heights — Publish
+                title.zh: "对话框高度：Publish"
+                title.zh-TW: "對話方塊高度：Publish"
                 type: variable-number-slider
                 document: PB005-Publish
                 format: 'vh'
@@ -46711,20 +47421,32 @@ settings:
     -
         id: info-editor-typography-split
         title: Note on Typography
+        title.zh: "排版说明"
+        title.zh-TW: "排版說明"
         type: info-text
         description: "Global typography settings (like global font sizes, underlines, bold, italic, and strikethrough) are controlled in the **Global Typography** section. Settings specific to the editor (like Header and Canvas font sizes) can be found within this Editor section."
+        description.zh: "全局字号、下划线、粗体、斜体和删除线等设置位于 **Global Typography** 区域。标题和白板字号等编辑器专用设置位于当前 **Editor** 区域。"
+        description.zh-TW: "全域字級、底線、粗體、斜體和刪除線等設定位於 **Global Typography** 區域。標題和白板字級等編輯器專用設定位於當前 **Editor** 區域。"
         markdown: true
     -
         id: info-editor-block-widths
         title: Note on Block Widths
+        title.zh: "内容块宽度说明"
+        title.zh-TW: "內容塊寬度說明"
         type: info-text
         description: "Block Widths are an optional feature and must be enabled to take effect. This feature is being progressively implemented and is currently available for **Bases**, **Tables**, **iFrames**, and **PDF Embeds**."
+        description.zh: "内容块宽度功能需要启用后才会生效。此功能正在逐步实现，目前支持**数据库（Bases）**、**表格**、**iFrame** 和**嵌入 PDF**。"
+        description.zh-TW: "內容塊寬度功能需要啟用後才會生效。此功能正在逐步實現，目前支援**資料庫（Bases）**、**表格**、**iFrame** 和**嵌入 PDF**。"
         markdown: true
     -
         id: global-block-width-mode
         title: "Block Widths — Master Control"
+        title.zh: "内容块宽度：总开关"
+        title.zh-TW: "內容塊寬度：總開關"
         type: variable-select
         description: "Use this to master-control for all block width features."
+        description.zh: "统一控制所有内容块宽度功能。 选项含义：Manual (Use individual toggles)：手动（使用各项开关）；Force All On：全部强制开启；Force All Off：全部强制关闭。"
+        description.zh-TW: "統一控制所有內容塊寬度功能。 選項含義：Manual (Use individual toggles)：手動（使用各項開關）；Force All On：全部強制開啟；Force All Off：全部強制關閉。"
         allowEmpty: false
         default: 'auto'
         options:
@@ -46740,16 +47462,24 @@ settings:
     -
         id: document-titlebar
         title: Document Titlebar
+        title.zh: "文档标题栏"
+        title.zh-TW: "文件標題列"
         type: heading
         description: 'Tweak the document titlebar.'
+        description.zh: "调整文档标题栏。"
+        description.zh-TW: "調整文件標題列。"
         level: 2
         collapsed: false
     -
             id: file-header-justify
             title: File Header Justification
+            title.zh: "文件标题对齐方式"
+            title.zh-TW: "檔案標題對齊方式"
             type: variable-select
             document: app.css
             description: "This option allows one to adjust the justification of the file header."
+            description.zh: "调整文件标题的对齐方式。 选项含义：Left：左；Center：居中；Right：右。"
+            description.zh-TW: "調整檔案標題的對齊方式。 選項含義：Left：左；Center：居中；Right：右。"
             default: center
             options:
                 -
@@ -46764,15 +47494,23 @@ settings:
     -
             id: info-tab-stacked-text
             title: Note on Stacked Tabs Text Direction and Alignment
+            title.zh: "堆叠标签页文本方向与对齐说明"
+            title.zh-TW: "堆疊標籤頁文本方向與對齊說明"
             type: class-toggle
             document: app.css
             description: "In order to keep the stacked tabs in their original position whilst changing their text direction, use the text alignment option and set it to the opposite of the original option. (Left > Right; Right > Left)"
+            description.zh: "更改堆叠标签页文本方向后，如需保持原位置，请同时将文本对齐方式设为原选项的反方向（Left 改为 Right，或 Right 改为 Left）。"
+            description.zh-TW: "更改堆疊標籤頁文本方向後，如需保持原位置，請同時將文本對齊方式設為原選項的反方向（Left 改為 Right，或 Right 改為 Left）。"
     -
             id: tab-stacked-text-transform
             title: Stacked Tabs Text Direction
+            title.zh: "堆叠标签页文本方向"
+            title.zh-TW: "堆疊標籤頁文本方向"
             type: variable-select
             document: app.css
             description: "This option allows one to adjust the text direction of the stacked tabs."
+            description.zh: "调整堆叠标签页的文本方向。 选项含义：Left-Facing：朝左；Right-Facing：朝右。"
+            description.zh-TW: "調整堆疊標籤頁的文本方向。 選項含義：Left-Facing：朝左；Right-Facing：朝右。"
             default: rotate(0deg)
             options:
                 -
@@ -46784,9 +47522,13 @@ settings:
     -
             id: tab-stacked-text-align
             title: Stacked Tabs Text Alignment
+            title.zh: "堆叠标签页文本对齐方式"
+            title.zh-TW: "堆疊標籤頁文本對齊方式"
             type: variable-select
             document: app.css
             description: "This option allows one to adjust the justification of the title of the stacked tabs."
+            description.zh: "调整堆叠标签页标题的对齐方式。 选项含义：Left：左；Center：居中；Right：右。"
+            description.zh-TW: "調整堆疊標籤頁標題的對齊方式。 選項含義：Left：左；Center：居中；Right：右。"
             default: left
             options:
                 -
@@ -46801,16 +47543,24 @@ settings:
     -
         id: codeblock-settings
         title: Codeblocks
+        title.zh: "代码块"
+        title.zh-TW: "程式碼塊"
         type: heading
         description: Options to change codeblock display.
+        description.zh: "调整代码块的显示方式。"
+        description.zh-TW: "調整程式碼塊的顯示方式。"
         level: 2
         collapsed: false
     -
             id: ssopt-codeblock-language
             title: Codeblock Language Display
+            title.zh: "代码块语言显示方式"
+            title.zh-TW: "程式碼塊語言顯示方式"
             type: class-select
             document: ED00-Elements
             description: "Use the dropdown to choose a codeblock language display type."
+            description.zh: "从下拉菜单选择代码块语言的显示方式。 选项含义：Default (UI font, flushed at bottom-right of codeblock)：默认（界面字体，代码块右下角）；Old-Style Willemstad & Shimmering Focus (Monospaced font, top-right of codeblock)：旧版样式（等宽字体，代码块右上角）；None：无。"
+            description.zh-TW: "從下拉選單選擇程式碼塊語言的顯示方式。 選項含義：Default (UI font, flushed at bottom-right of codeblock)：預設（介面字型，程式碼塊右下角）；Old-Style Willemstad & Shimmering Focus (Monospaced font, top-right of codeblock)：舊版樣式（等寬字型，程式碼塊右上角）；None：無。"
             default: default
             options:
                 -
@@ -46825,29 +47575,45 @@ settings:
     -
         id: active-line-highlight
         title: Active Line Highlight
+        title.zh: "当前行高亮"
+        title.zh-TW: "當前行高亮"
         type: heading
         description: Options to change the active line highlighting in the editing modes.
+        description.zh: "调整编辑模式下的当前行高亮。"
+        description.zh-TW: "調整編輯模式下的當前行高亮。"
         level: 2
         collapsed: false
     -
             id: ssopt-disable-alh
             title: Disable Active Line Highlight
+            title.zh: "禁用当前行高亮"
+            title.zh-TW: "停用當前行高亮"
             type: class-toggle
             document: ED03-ActiveLineHighlight
             description: "Willemstad has active line highlights by default across the specific line you're editing on. When toggled, this disables the highlighting."
+            description.zh: "Willemstad 默认高亮正在编辑的行。启用此项后，禁用当前行高亮。"
+            description.zh-TW: "Willemstad 預設高亮正在編輯的行。啟用此項後，停用當前行高亮。"
             default: false
             addCommand: true
     -
             id: col-base-bg-alh
             title: Colour for Active Line Highlight
+            title.zh: "当前行高亮颜色"
+            title.zh-TW: "當前行高亮顏色"
             type: variable-text
             description: "Sets the base colour for the active line highlight. The theme will apply transparency to this colour. Accepts any valid CSS colour format (e.g., hex, rgb, oklch, var(--color-accent)). Please note that the input field is meant to be colour-responsive and mimics how the Active Line Highlight looks in the editor when in focus."
+            description.zh: "设置当前行高亮的基础颜色，主题会为其应用透明度。接受有效的 CSS 颜色格式，如 hex、rgb、oklch 或 var(--color-accent)。输入框会响应颜色变化，模拟编辑器获得焦点时的当前行高亮效果。"
+            description.zh-TW: "設定當前行高亮的基礎顏色，主題會為其應用透明度。接受有效的 CSS 顏色格式，如 hex、rgb、oklch 或 var(--color-accent)。輸入框會響應顏色變化，模擬編輯器獲得焦點時的當前行高亮效果。"
             default: 'var(--color-base-50)'
     -
             id: col-base-alpha-alh
             title: Opacity of Active Line Highlight
+            title.zh: "当前行高亮不透明度"
+            title.zh-TW: "當前行高亮不透明度"
             type: variable-number-slider
             description: "Controls the opacity of the active line highlight. Lower values are more transparent. The default is 0.25; you are recommended to set values below 0.5."
+            description.zh: "控制当前行高亮的不透明度，数值越低越透明。默认为 0.25，建议低于 0.5。"
+            description.zh-TW: "控制當前行高亮的不透明度，數值越低越透明。預設為 0.25，建議低於 0.5。"
             format: ""
             min: 0
             max: 1
@@ -46856,23 +47622,35 @@ settings:
     -
         id: variable-line-lengths
         title: "Editor Pane Manipulation (Readable Line Lengths and Pane Margins)"
+        title.zh: "编辑器面板设置（阅读行宽与面板边距）"
+        title.zh-TW: "編輯器面板設定（閱讀行寬與面板邊距）"
         type: heading
         description: "Options to change the line lengths and pane margin/padding of the editor."
+        description.zh: "调整编辑器行宽，以及面板内外边距。"
+        description.zh-TW: "調整編輯器行寬，以及面板內外邊距。"
         level: 2
         collapsed: false
     -
             id: width-vll
             title: Custom Maximum Line Length for Readable Line Lengths
+            title.zh: "自定义阅读模式最大行宽"
+            title.zh-TW: "自訂閱讀模式最大行寬"
             type: variable-text
             document: ED01-VarLineLength
             notes: (Requires 'Override Line Lengths' enabled)
             description: "Set the maximum line length. Accepts all valid CSS units. Requires Obsidian's own 'Readable Line Lengths' option toggled on for this to work."
+            description.zh: "设置最大行宽，接受有效的 CSS 单位。需先在 Obsidian 中开启“缩减栏宽”（Readable Line Length）才能生效。"
+            description.zh-TW: "設定最大行寬，接受有效的 CSS 單位。需先在 Obsidian 中開啟“縮減欄寬”（Readable Line Length）才能生效。"
             default: 700px
     -
             id: file-margins
             title: Pane Margins in Editing Workspace
+            title.zh: "编辑工作区面板边距"
+            title.zh-TW: "編輯工作區面板邊距"
             type: variable-number-slider
             description: "Controls the padding on all sides within the editor pane, creating more or less 'breathing room' around your content. Please note that this option might affect components such as header numbering and header collapse indicators. The default is 32px."
+            description.zh: "控制编辑器面板四周的内边距，调整内容周围的留白。此设置可能影响标题级别标记和折叠指示器等元素。默认为 32px。"
+            description.zh-TW: "控制編輯器面板四周的內邊距，調整內容周圍的留白。此設定可能影響標題級別標記和摺疊指示器等元素。預設為 32px。"
             format: "px"
             min: 20
             max: 60
@@ -46881,66 +47659,102 @@ settings:
     -
         id: headers
         title: Headers
+        title.zh: "标题"
+        title.zh-TW: "標題"
         type: heading
         description: Options to change the headers.
+        description.zh: "调整标题样式。"
+        description.zh-TW: "調整標題樣式。"
         level: 2
         collapsed: false
     -
         id: ssopt-add-header-number
         title: Add Header Number (H1-H6)
+        title.zh: "添加标题级别标记（H1-H6）"
+        title.zh-TW: "新增標題級別標記（H1-H6）"
         type: class-toggle
         document: EH91-HAdditions
         description: "When enabled, this will add the header number to the left side just outside of the header to enable easier identification."
+        description.zh: "启用后，在标题左侧外部显示标题级别标记，便于识别。"
+        description.zh-TW: "啟用後，在標題左側外部顯示標題級別標記，便於識別。"
         default: false
     -
         id: coloured-headers
         title: Coloured Headers
+        title.zh: "彩色标题"
+        title.zh-TW: "彩色標題"
         type: heading
         description: Options for coloured headers.
+        description.zh: "彩色标题选项。"
+        description.zh-TW: "彩色標題選項。"
         level: 3
         collapsed: true
     -
             id: info-coloured-headers
             title: Note on Coloured Headers
+            title.zh: "彩色标题说明"
+            title.zh-TW: "彩色標題說明"
             type: class-toggle
             description: "By default, Willemstad uses the accent colours (--color-accent, --color-accent-1 and --color-accent-2) to colour the background of the headers. You can customise these by enabling 'Custom Header Colours (Background Colours)'. For legacy users of Willemstad, the previous header styles are available under 'Old Willemstad Header Colours'. If you prefer no background colours but coloured header text, please toggle the 'No Background Coloured Headers' option."  
+            description.zh: "Willemstad 默认使用强调色（--color-accent、--color-accent-1 和 --color-accent-2）作为标题背景。启用“自定义标题颜色（背景色）”可修改；旧版样式位于“旧版 Willemstad 标题颜色”。如只需彩色文字而不需要背景色，请启用“移除标题背景色”。"
+            description.zh-TW: "Willemstad 預設使用強調色（--color-accent、--color-accent-1 和 --color-accent-2）作為標題背景。啟用“自訂標題顏色（背景色）”可修改；舊版樣式位於“舊版 Willemstad 標題顏色”。如只需彩色文字而不需要背景色，請啟用“移除標題背景色”。"
             default: false    
     -
             id: info-coloured-headers-text
             title: Note on Header Text Colours
+            title.zh: "标题文字颜色说明"
+            title.zh-TW: "標題文字顏色說明"
             type: class-toggle
             description: "If the Background Coloured Headers are enabled, Willemstad sets the header text colours mathematically in accordance to the colours chosen for your headers."  
+            description.zh: "启用标题背景色时，Willemstad 根据所选背景色计算标题文字颜色。"
+            description.zh-TW: "啟用標題背景色時，Willemstad 根據所選背景色計算標題文字顏色。"
             default: false    
     -
             id: ssopt-no-coloured-headers
             title: No Background Coloured Headers
+            title.zh: "移除标题背景色"
+            title.zh-TW: "移除標題背景色"
             type: class-toggle
             document: EH01-HSetBase
             description: "Headers with background colours are enabled by default in Willemstad. When enabled, this will remove the background colouring for headers, and also optionally allows you to set headers with coloured text."
+            description.zh: "Willemstad 默认启用标题背景色。此项移除标题背景色，同时允许单独设置彩色标题文字。"
+            description.zh-TW: "Willemstad 預設啟用標題背景色。此項移除標題背景色，同時允許單獨設定彩色標題文字。"
             default: false
     -
             id: ssopt-headers-custom-colours
             title: Custom Header Colours (Background Colours)
+            title.zh: "自定义标题颜色（背景色）"
+            title.zh-TW: "自訂標題顏色（背景色）"
             type: class-toggle
             document: EH13-HCol-Custom
             notes: (Requires 'No Background Coloured Headers' disabled)
             description: "When enabled, this will allow you to set custom header colours."
+            description.zh: "启用后，可自定义标题颜色。"
+            description.zh-TW: "啟用後，可自訂標題顏色。"
             default: false
     -
             id: ssopt-headers-old-willemstad
             title: Old Willemstad Header Colours
+            title.zh: "旧版 Willemstad 标题颜色"
+            title.zh-TW: "舊版 Willemstad 標題顏色"
             type: class-toggle
             document: EH12-HCol-OldStad
             notes: (Requires 'No Background Coloured Headers' disabled)
             description: "When enabled, this will use the old Willemstad header colours. There are two options for the old header colours: the original Willemstad colours, and the old Willemstad-style Nord colours."
+            description.zh: "启用后，使用旧版 Willemstad 标题配色。可选择原始 Willemstad 配色或旧版 Willemstad 风格的 Nord 配色。"
+            description.zh-TW: "啟用後，使用舊版 Willemstad 標題配色。可選擇原始 Willemstad 配色或舊版 Willemstad 風格的 Nord 配色。"
             default: false
     -
             id: ssopt-headers-old-style-col-palette
             title: Old Header Colour Palettes
+            title.zh: "旧版标题配色方案"
+            title.zh-TW: "舊版標題配色方案"
             type: class-select
             document: EH12-HCol-OldStad
             notes: (Requires 'No Background Coloured Headers' disabled; Requires 'Old Willemstad Header Colours' enabled)
             description: "Use the dropdown to choose either the original Willemstad colours, or the old Willemstad-style Nord colours."
+            description.zh: "从下拉菜单选择原始 Willemstad 配色或旧版 Willemstad 风格的 Nord 配色。 选项含义：Original Willemstad：原始 Willemstad；Previous Willemstad-style Nord：旧版 Willemstad 风格 Nord。"
+            description.zh-TW: "從下拉選單選擇原始 Willemstad 配色或舊版 Willemstad 風格的 Nord 配色。 選項含義：Original Willemstad：原始 Willemstad；Previous Willemstad-style Nord：舊版 Willemstad 風格 Nord。"
             default: ssopt-headers-old-style-willemstad
             options:
                 -
@@ -46952,10 +47766,14 @@ settings:
     -
             id: col-accent-custom-headers-0
             title: Custom Header Colour 0
+            title.zh: "自定义标题颜色 0"
+            title.zh-TW: "自訂標題顏色 0"
             type: variable-themed-color
             document: EH13-HCol-Custom
             notes: (Requires 'No Background Coloured Headers' disabled; Requires 'Custom Header Colours' enabled)
             description: "This header colour is applied to H1 (and H4 headers, if 'Complete Header Colour Control' is not enabled)."
+            description.zh: "应用于 H1 标题；未启用“独立控制全部标题颜色”时，也应用于 H4。"
+            description.zh-TW: "應用於 H1 標題；未啟用“獨立控制全部標題顏色”時，也應用於 H4。"
             opacity: false
             format: hsl
             default-light: hsl(211, 100%, 19%)
@@ -46963,10 +47781,14 @@ settings:
     -
             id: col-accent-custom-headers-1
             title: Custom Header Colour 1
+            title.zh: "自定义标题颜色 1"
+            title.zh-TW: "自訂標題顏色 1"
             type: variable-themed-color
             document: EH13-HCol-Custom
             notes: (Requires 'No Background Coloured Headers' disabled; Requires 'Custom Header Colours' enabled)
             description: "This header colour is applied to H2 (and H5 headers, if 'Complete Header Colour Control' is not enabled)."
+            description.zh: "应用于 H2 标题；未启用“独立控制全部标题颜色”时，也应用于 H5。"
+            description.zh-TW: "應用於 H2 標題；未啟用“獨立控制全部標題顏色”時，也應用於 H5。"
             opacity: false
             format: hsl
             default-light: hsl(181, 100%, 32%)
@@ -46974,10 +47796,14 @@ settings:
     -
             id: col-accent-custom-headers-2
             title: Custom Header Colour 2
+            title.zh: "自定义标题颜色 2"
+            title.zh-TW: "自訂標題顏色 2"
             type: variable-themed-color
             document: EH13-HCol-Custom
             notes: (Requires 'No Background Coloured Headers' disabled; Requires 'Custom Header Colours' enabled)
             description: "This header colour is applied to H3 (and H6 headers, if 'Complete Header Colour Control' is not enabled)."
+            description.zh: "应用于 H3 标题；未启用“独立控制全部标题颜色”时，也应用于 H6。"
+            description.zh-TW: "應用於 H3 標題；未啟用“獨立控制全部標題顏色”時，也應用於 H6。"
             opacity: false
             format: hsl
             default-light: hsl(161, 100%, 41%)
@@ -46985,18 +47811,26 @@ settings:
     -
             id: ssopt-headers-custom-colours-max
             title: Complete Header Colour Control
+            title.zh: "独立控制全部标题颜色"
+            title.zh-TW: "獨立控制全部標題顏色"
             type: class-toggle
             document: EH13-HCol-Custom
             notes: (Requires 'No Background Coloured Headers' disabled; Requires 'Custom Header Colours' enabled)
             description: "When enabled, this will allow you to fully customise all header colours."
+            description.zh: "启用后，可分别自定义所有级别的标题颜色。"
+            description.zh-TW: "啟用後，可分別自訂所有級別的標題顏色。"
             default: false
     -
             id: col-accent-custom-headers-0B
             title: Custom Header Colour H4
+            title.zh: "自定义 H4 标题颜色"
+            title.zh-TW: "自訂 H4 標題顏色"
             type: variable-themed-color
             document: EH13-HCol-Custom
             notes: (Requires 'No Background Coloured Headers' disabled; Requires 'Custom Header Colours' and 'Complete Header Colour Control' enabled)
             description: 'This header colour is applied to H4 headers.'
+            description.zh: "应用于 H4 标题。"
+            description.zh-TW: "應用於 H4 標題。"
             opacity: false
             format: hsl
             default-light: hsl(211, 100%, 19%)
@@ -47004,10 +47838,14 @@ settings:
     -
             id: col-accent-custom-headers-1B
             title: Custom Header Colour H5
+            title.zh: "自定义 H5 标题颜色"
+            title.zh-TW: "自訂 H5 標題顏色"
             type: variable-themed-color
             document: EH13-HCol-Custom
             notes: (Requires 'No Background Coloured Headers' disabled; Requires 'Custom Header Colours' and 'Complete Header Colour Control' enabled)
             description: 'This header colour is applied to H5 headers.'
+            description.zh: "应用于 H5 标题。"
+            description.zh-TW: "應用於 H5 標題。"
             opacity: false
             format: hsl
             default-light: hsl(181, 100%, 32%)
@@ -47015,10 +47853,14 @@ settings:
     -
             id: col-accent-custom-headers-2B
             title: Custom Header Colour H6
+            title.zh: "自定义 H6 标题颜色"
+            title.zh-TW: "自訂 H6 標題顏色"
             type: variable-themed-color
             document: EH13-HCol-Custom
             notes: (Requires 'No Background Coloured Headers' disabled; Requires 'Custom Header Colours' and 'Complete Header Colour Control' enabled)
             description: 'This header colour is applied to H6 headers.'
+            description.zh: "应用于 H6 标题。"
+            description.zh-TW: "應用於 H6 標題。"
             opacity: false
             format: hsl
             default-light: hsl(161, 100%, 41%)
@@ -47026,10 +47868,14 @@ settings:
     -
             id: col-custom-headers-H1
             title: Custom Header Text Colour H1
+            title.zh: "自定义 H1 标题文字颜色"
+            title.zh-TW: "自訂 H1 標題文字顏色"
             type: variable-themed-color
             document: EH13-HCol-Custom
             notes: (Requires 'No Background Coloured Headers' disabled; Requires 'Custom Header Colours' and 'Complete Header Colour Control' enabled)
             description: 'This text colour is applied to H1 headers.'
+            description.zh: "应用于 H1 标题文字。"
+            description.zh-TW: "應用於 H1 標題文字。"
             opacity: false
             format: hsl
             default-light: hsl(0, 0%, 100%)
@@ -47037,10 +47883,14 @@ settings:
     -
             id: col-custom-headers-H2
             title: Custom Header Text Colour H2
+            title.zh: "自定义 H2 标题文字颜色"
+            title.zh-TW: "自訂 H2 標題文字顏色"
             type: variable-themed-color
             document: EH13-HCol-Custom
             notes: (Requires 'No Background Coloured Headers' disabled; Requires 'Custom Header Colours' and 'Complete Header Colour Control' enabled)
             description: 'This text colour is applied to H2 headers.'
+            description.zh: "应用于 H2 标题文字。"
+            description.zh-TW: "應用於 H2 標題文字。"
             opacity: false
             format: hsl
             default-light: hsl(0, 0%, 100%)
@@ -47048,10 +47898,14 @@ settings:
     -
             id: col-custom-headers-H3
             title: Custom Header Text Colour H3
+            title.zh: "自定义 H3 标题文字颜色"
+            title.zh-TW: "自訂 H3 標題文字顏色"
             type: variable-themed-color
             document: EH13-HCol-Custom
             notes: (Requires 'No Background Coloured Headers' disabled; Requires 'Custom Header Colours' and 'Complete Header Colour Control' enabled)
             description: 'This text colour is applied to H3 headers.'
+            description.zh: "应用于 H3 标题文字。"
+            description.zh-TW: "應用於 H3 標題文字。"
             opacity: false
             format: hsl
             default-light: hsl(0, 0%, 100%)
@@ -47059,10 +47913,14 @@ settings:
     -
             id: col-custom-headers-H4
             title: Custom Header Text Colour H4
+            title.zh: "自定义 H4 标题文字颜色"
+            title.zh-TW: "自訂 H4 標題文字顏色"
             type: variable-themed-color
             document: EH13-HCol-Custom
             notes: (Requires 'No Background Coloured Headers' disabled; Requires 'Custom Header Colours' and 'Complete Header Colour Control' enabled)
             description: 'This text colour is applied to H4 headers.'
+            description.zh: "应用于 H4 标题文字。"
+            description.zh-TW: "應用於 H4 標題文字。"
             opacity: false
             format: hsl
             default-light: hsl(0, 0%, 100%)
@@ -47070,10 +47928,14 @@ settings:
     -
             id: col-custom-headers-H5
             title: Custom Header Text Colour H5
+            title.zh: "自定义 H5 标题文字颜色"
+            title.zh-TW: "自訂 H5 標題文字顏色"
             type: variable-themed-color
             document: EH13-HCol-Custom
             notes: (Requires 'No Background Coloured Headers' disabled; Requires 'Custom Header Colours' and 'Complete Header Colour Control' enabled)
             description: 'This text colour is applied to H5 headers.'
+            description.zh: "应用于 H5 标题文字。"
+            description.zh-TW: "應用於 H5 標題文字。"
             opacity: false
             format: hsl
             default-light: hsl(0, 0%, 100%)
@@ -47081,10 +47943,14 @@ settings:
     -
             id: col-custom-headers-H6
             title: Custom Header Text Colour H6
+            title.zh: "自定义 H6 标题文字颜色"
+            title.zh-TW: "自訂 H6 標題文字顏色"
             type: variable-themed-color
             document: EH13-HCol-Custom
             notes: (Requires 'No Background Coloured Headers' disabled; Requires 'Custom Header Colours' and 'Complete Header Colour Control' enabled)
             description: 'This text colour is applied to H6 headers.'
+            description.zh: "应用于 H6 标题文字。"
+            description.zh-TW: "應用於 H6 標題文字。"
             opacity: false
             format: hsl
             default-light: hsl(0, 0%, 100%)
@@ -47093,19 +47959,27 @@ settings:
     -
         id: header-text-colours
         title: Header Text Colours
+        title.zh: "标题文字颜色"
+        title.zh-TW: "標題文字顏色"
         type: heading
         description: "These settings allow you to set the color for each header level from the set accent and rainbow palettes, should you prefer coloured text. These settings will automatically show you the options for the current light/dark theme mode. You are able to set different header text colours for both modes without them affecting each other."
+        description.zh: "如需彩色标题文字，可为各级标题选择强调色或彩虹色。此处仅显示当前浅色或深色模式对应的选项，两种模式可独立设置、互不影响。"
+        description.zh-TW: "如需彩色標題文字，可為各級標題選擇強調色或彩虹色。此處僅顯示當前淺色或深色模式對應的選項，兩種模式可獨立設定、互不影響。"
         level: 3
         collapsed: false
     -
             id: header-text-colours-light
             title: Light Mode
+            title.zh: "浅色模式"
+            title.zh-TW: "淺色模式"
             type: heading
             level: 4
             collapsed: false
     -
                 id: h1-color-light
                 title: "H1 Color"
+                title.zh: "H1 颜色"
+                title.zh-TW: "H1 顏色"
                 type: variable-select
                 allowEmpty: false
                 default: 'inherit'
@@ -47155,6 +48029,8 @@ settings:
     -
                 id: h2-color-light
                 title: "H2 Color"
+                title.zh: "H2 颜色"
+                title.zh-TW: "H2 顏色"
                 type: variable-select
                 allowEmpty: false
                 default: 'inherit'
@@ -47204,6 +48080,8 @@ settings:
     -
                 id: h3-color-light
                 title: "H3 Color"
+                title.zh: "H3 颜色"
+                title.zh-TW: "H3 顏色"
                 type: variable-select
                 allowEmpty: false
                 default: 'inherit'
@@ -47253,6 +48131,8 @@ settings:
     -
                 id: h4-color-light
                 title: "H4 Color"
+                title.zh: "H4 颜色"
+                title.zh-TW: "H4 顏色"
                 type: variable-select
                 allowEmpty: false
                 default: 'inherit'
@@ -47302,6 +48182,8 @@ settings:
     -
                 id: h5-color-light
                 title: "H5 Color"
+                title.zh: "H5 颜色"
+                title.zh-TW: "H5 顏色"
                 type: variable-select
                 allowEmpty: false
                 default: 'inherit'
@@ -47351,6 +48233,8 @@ settings:
     -
                 id: h6-color-light
                 title: "H6 Color"
+                title.zh: "H6 颜色"
+                title.zh-TW: "H6 顏色"
                 type: variable-select
                 allowEmpty: false
                 default: 'inherit'
@@ -47400,12 +48284,16 @@ settings:
     -
             id: header-text-colours-dark
             title: Dark Mode
+            title.zh: "深色模式"
+            title.zh-TW: "深色模式"
             type: heading
             level: 4
             collapsed: false
     -
                 id: h1-color-dark
                 title: "H1 Color"
+                title.zh: "H1 颜色"
+                title.zh-TW: "H1 顏色"
                 type: variable-select
                 allowEmpty: false
                 default: 'inherit'
@@ -47455,6 +48343,8 @@ settings:
     -
                 id: h2-color-dark
                 title: "H2 Color"
+                title.zh: "H2 颜色"
+                title.zh-TW: "H2 顏色"
                 type: variable-select
                 allowEmpty: false
                 default: 'inherit'
@@ -47504,6 +48394,8 @@ settings:
     -
                 id: h3-color-dark
                 title: "H3 Color"
+                title.zh: "H3 颜色"
+                title.zh-TW: "H3 顏色"
                 type: variable-select
                 allowEmpty: false
                 default: 'inherit'
@@ -47553,6 +48445,8 @@ settings:
     -
                 id: h4-color-dark
                 title: "H4 Color"
+                title.zh: "H4 颜色"
+                title.zh-TW: "H4 顏色"
                 type: variable-select
                 allowEmpty: false
                 default: 'inherit'
@@ -47602,6 +48496,8 @@ settings:
     -
                 id: h5-color-dark
                 title: "H5 Color"
+                title.zh: "H5 颜色"
+                title.zh-TW: "H5 顏色"
                 type: variable-select
                 allowEmpty: false
                 default: 'inherit'
@@ -47651,6 +48547,8 @@ settings:
     -
                 id: h6-color-dark
                 title: "H6 Color"
+                title.zh: "H6 颜色"
+                title.zh-TW: "H6 顏色"
                 type: variable-select
                 allowEmpty: false
                 default: 'inherit'
@@ -47700,19 +48598,27 @@ settings:
     -
         id: header-typography-settings
         title: Header Typography
+        title.zh: "标题排版"
+        title.zh-TW: "標題排版"
         type: heading
         description: "Provides detailed control over the font size, weight, and style for each header level."
+        description.zh: "分别控制各级标题的字号、字重和字体样式。"
+        description.zh-TW: "分別控制各級標題的字級、字重和字型樣式。"
         level: 3
         collapsed: true
     -
         id: h1-settings
         title: H1 Settings
+        title.zh: "H1 设置"
+        title.zh-TW: "H1 設定"
         type: heading
         level: 4
         collapsed: true
     -
         id: h1-size
         title: Font Size
+        title.zh: "字号"
+        title.zh-TW: "字級"
         type: variable-number-slider
         format: "em"
         min: 1
@@ -47722,6 +48628,8 @@ settings:
     -
         id: h1-weight
         title: Font Weight
+        title.zh: "字重"
+        title.zh-TW: "字重"
         type: variable-number-slider
         min: 100
         max: 900
@@ -47730,6 +48638,10 @@ settings:
     -
         id: h1-style
         title: Font Style
+        title.zh: "字体样式"
+        title.zh-TW: "字型樣式"
+        description.zh: "选项含义：Normal：常规；Italic：斜体；Oblique：倾斜。"
+        description.zh-TW: "選項含義：Normal：常規；Italic：斜體；Oblique：傾斜。"
         type: variable-select
         allowEmpty: false
         default: 'normal'
@@ -47746,6 +48658,10 @@ settings:
     -
         id: h1-variant
         title: Font Variant
+        title.zh: "字体变体"
+        title.zh-TW: "字型變體"
+        description.zh: "选项含义：Normal：常规；Small Caps：小型大写；All Small Caps：全部小型大写。"
+        description.zh-TW: "選項含義：Normal：常規；Small Caps：小型大寫；All Small Caps：全部小型大寫。"
         type: variable-select
         allowEmpty: false
         default: 'normal'
@@ -47762,12 +48678,16 @@ settings:
     -
         id: h2-settings
         title: H2 Settings
+        title.zh: "H2 设置"
+        title.zh-TW: "H2 設定"
         type: heading
         level: 4
         collapsed: true
     -
         id: h2-size
         title: Font Size
+        title.zh: "字号"
+        title.zh-TW: "字級"
         type: variable-number-slider
         format: "em"
         min: 1
@@ -47777,6 +48697,8 @@ settings:
     -
         id: h2-weight
         title: Font Weight
+        title.zh: "字重"
+        title.zh-TW: "字重"
         type: variable-number-slider
         min: 100
         max: 900
@@ -47785,6 +48707,10 @@ settings:
     -
         id: h2-style
         title: Font Style
+        title.zh: "字体样式"
+        title.zh-TW: "字型樣式"
+        description.zh: "选项含义：Normal：常规；Italic：斜体；Oblique：倾斜。"
+        description.zh-TW: "選項含義：Normal：常規；Italic：斜體；Oblique：傾斜。"
         type: variable-select
         allowEmpty: false
         default: 'normal'
@@ -47801,6 +48727,10 @@ settings:
     -
         id: h2-variant
         title: Font Variant
+        title.zh: "字体变体"
+        title.zh-TW: "字型變體"
+        description.zh: "选项含义：Normal：常规；Small Caps：小型大写；All Small Caps：全部小型大写。"
+        description.zh-TW: "選項含義：Normal：常規；Small Caps：小型大寫；All Small Caps：全部小型大寫。"
         type: variable-select
         allowEmpty: false
         default: 'normal'
@@ -47817,12 +48747,16 @@ settings:
     -
         id: h3-settings
         title: H3 Settings
+        title.zh: "H3 设置"
+        title.zh-TW: "H3 設定"
         type: heading
         level: 4
         collapsed: true
     -
         id: h3-size
         title: Font Size
+        title.zh: "字号"
+        title.zh-TW: "字級"
         type: variable-number-slider
         format: "em"
         min: 1
@@ -47832,6 +48766,8 @@ settings:
     -
         id: h3-weight
         title: Font Weight
+        title.zh: "字重"
+        title.zh-TW: "字重"
         type: variable-number-slider
         min: 100
         max: 900
@@ -47840,6 +48776,10 @@ settings:
     -
         id: h3-style
         title: Font Style
+        title.zh: "字体样式"
+        title.zh-TW: "字型樣式"
+        description.zh: "选项含义：Normal：常规；Italic：斜体；Oblique：倾斜。"
+        description.zh-TW: "選項含義：Normal：常規；Italic：斜體；Oblique：傾斜。"
         type: variable-select
         allowEmpty: false
         default: 'normal'
@@ -47856,6 +48796,10 @@ settings:
     -
         id: h3-variant
         title: Font Variant
+        title.zh: "字体变体"
+        title.zh-TW: "字型變體"
+        description.zh: "选项含义：Normal：常规；Small Caps：小型大写；All Small Caps：全部小型大写。"
+        description.zh-TW: "選項含義：Normal：常規；Small Caps：小型大寫；All Small Caps：全部小型大寫。"
         type: variable-select
         allowEmpty: false
         default: 'normal'
@@ -47872,12 +48816,16 @@ settings:
     -
         id: h4-settings
         title: H4 Settings
+        title.zh: "H4 设置"
+        title.zh-TW: "H4 設定"
         type: heading
         level: 4
         collapsed: true
     -
         id: h4-size
         title: Font Size
+        title.zh: "字号"
+        title.zh-TW: "字級"
         type: variable-number-slider
         format: "em"
         min: 1
@@ -47887,6 +48835,8 @@ settings:
     -
         id: h4-weight
         title: Font Weight
+        title.zh: "字重"
+        title.zh-TW: "字重"
         type: variable-number-slider
         min: 100
         max: 900
@@ -47895,6 +48845,10 @@ settings:
     -
         id: h4-style
         title: Font Style
+        title.zh: "字体样式"
+        title.zh-TW: "字型樣式"
+        description.zh: "选项含义：Normal：常规；Italic：斜体；Oblique：倾斜。"
+        description.zh-TW: "選項含義：Normal：常規；Italic：斜體；Oblique：傾斜。"
         type: variable-select
         allowEmpty: false
         default: 'normal'
@@ -47911,6 +48865,10 @@ settings:
     -
         id: h4-variant
         title: Font Variant
+        title.zh: "字体变体"
+        title.zh-TW: "字型變體"
+        description.zh: "选项含义：Normal：常规；Small Caps：小型大写；All Small Caps：全部小型大写。"
+        description.zh-TW: "選項含義：Normal：常規；Small Caps：小型大寫；All Small Caps：全部小型大寫。"
         type: variable-select
         allowEmpty: false
         default: 'normal'
@@ -47927,12 +48885,16 @@ settings:
     -
         id: h5-settings
         title: H5 Settings
+        title.zh: "H5 设置"
+        title.zh-TW: "H5 設定"
         type: heading
         level: 4
         collapsed: true
     -
         id: h5-size
         title: Font Size
+        title.zh: "字号"
+        title.zh-TW: "字級"
         type: variable-number-slider
         format: "em"
         min: 1
@@ -47942,6 +48904,8 @@ settings:
     -
         id: h5-weight
         title: Font Weight
+        title.zh: "字重"
+        title.zh-TW: "字重"
         type: variable-number-slider
         min: 100
         max: 900
@@ -47950,6 +48914,10 @@ settings:
     -
         id: h5-style
         title: Font Style
+        title.zh: "字体样式"
+        title.zh-TW: "字型樣式"
+        description.zh: "选项含义：Normal：常规；Italic：斜体；Oblique：倾斜。"
+        description.zh-TW: "選項含義：Normal：常規；Italic：斜體；Oblique：傾斜。"
         type: variable-select
         allowEmpty: false
         default: 'normal'
@@ -47966,6 +48934,10 @@ settings:
     -
         id: h5-variant
         title: Font Variant
+        title.zh: "字体变体"
+        title.zh-TW: "字型變體"
+        description.zh: "选项含义：Normal：常规；Small Caps：小型大写；All Small Caps：全部小型大写。"
+        description.zh-TW: "選項含義：Normal：常規；Small Caps：小型大寫；All Small Caps：全部小型大寫。"
         type: variable-select
         allowEmpty: false
         default: 'normal'
@@ -47982,12 +48954,16 @@ settings:
     -
         id: h6-settings
         title: H6 Settings
+        title.zh: "H6 设置"
+        title.zh-TW: "H6 設定"
         type: heading
         level: 4
         collapsed: true
     -
         id: h6-size
         title: Font Size
+        title.zh: "字号"
+        title.zh-TW: "字級"
         type: variable-number-slider
         format: "em"
         min: 1
@@ -47997,6 +48973,8 @@ settings:
     -
         id: h6-weight
         title: Font Weight
+        title.zh: "字重"
+        title.zh-TW: "字重"
         type: variable-number-slider
         min: 100
         max: 900
@@ -48005,6 +48983,10 @@ settings:
     -
         id: h6-style
         title: Font Style
+        title.zh: "字体样式"
+        title.zh-TW: "字型樣式"
+        description.zh: "选项含义：Normal：常规；Italic：斜体；Oblique：倾斜。"
+        description.zh-TW: "選項含義：Normal：常規；Italic：斜體；Oblique：傾斜。"
         type: variable-select
         allowEmpty: false
         default: 'normal'
@@ -48021,6 +49003,10 @@ settings:
     -
         id: h6-variant
         title: Font Variant
+        title.zh: "字体变体"
+        title.zh-TW: "字型變體"
+        description.zh: "选项含义：Normal：常规；Small Caps：小型大写；All Small Caps：全部小型大写。"
+        description.zh-TW: "選項含義：Normal：常規；Small Caps：小型大寫；All Small Caps：全部小型大寫。"
         type: variable-select
         allowEmpty: false
         default: 'normal'
@@ -48037,24 +49023,36 @@ settings:
     -
         id: header-hexes
         title: Header Hexes
+        title.zh: "标题井号"
+        title.zh-TW: "標題井號"
         type: heading
         description: Options to change the header hexes (# at the start of a heading).
+        description.zh: "调整标题开头的井号（#）。"
+        description.zh-TW: "調整標題開頭的井號（#）。"
         level: 3
         collapsed: true
     -
             id: ssopt-smaller-header-hexes
             title: Make Header Hexes Smaller
+            title.zh: "缩小标题井号"
+            title.zh-TW: "縮小標題井號"
             type: class-toggle
             document: EH91-HAdditions
             description: "Headers Hexes (#) in Obsidian take the same font size as the header text. This option makes them smaller."
+            description.zh: "Obsidian 默认让标题井号（#）与标题文字等大。启用此项可缩小井号。"
+            description.zh-TW: "Obsidian 預設讓標題井號（#）與標題文字等大。啟用此項可縮小井號。"
             default: false
     -
             id: header-hex-size
             title: Size of Header Hexes
+            title.zh: "标题井号大小"
+            title.zh-TW: "標題井號大小"
             type: variable-number-slider
             document: EH91-HAdditions
             note: (Requires 'Make Header Hexes Smaller' enabled)
             description: "Change the size of the header hexes, relative to the header text's own font size. The default is 0.7em."
+            description.zh: "设置标题井号相对于标题文字字号的大小。默认为 0.7em。"
+            description.zh-TW: "設定標題井號相對於標題文字字級的大小。預設為 0.7em。"
             format: 'em'
             default: 0.7
             min: 0.1
@@ -48063,9 +49061,13 @@ settings:
     -
             id: col-header-hex
             title: Colour of Header Hexes
+            title.zh: "标题井号颜色"
+            title.zh-TW: "標題井號顏色"
             type: variable-select
             document: EH91-HAdditions
             description: "Use the dropdown to choose the colour of the header hexes. While text-faint is the default in Obsidian, this is harder to discern with coloured headers. Willemstad matches the header hexes colours to that of the header text."
+            description.zh: "选择标题井号的颜色。Obsidian 默认使用 text-faint，但在彩色标题中可能难以辨认；Willemstad 默认让井号与标题文字同色。 选项含义：Match Colour of Header Hexes to Header Text：井号与标题文字同色。"
+            description.zh-TW: "選擇標題井號的顏色。Obsidian 預設使用 text-faint，但在彩色標題中可能難以辨認；Willemstad 預設讓井號與標題文字同色。 選項含義：Match Colour of Header Hexes to Header Text：井號與標題文字同色。"
             allowEmpty: false
             default: var(--col-header-hex-special)
             options:
@@ -48081,44 +49083,68 @@ settings:
     -
         id: empty-state-screen
         title: Empty State Screen
+        title.zh: "空白页画面"
+        title.zh-TW: "空白頁畫面"
         type: heading
         description: "Options to customise the empty state screen (the screen that is displayed when no note is opened)."
+        description.zh: "自定义未打开任何笔记时显示的空白页画面。"
+        description.zh-TW: "自訂未開啟任何筆記時顯示的空白頁畫面。"
         level: 2
         collapsed: false
     -
             id: ssopt-empty-state-original
             title: Revert to Default Empty State Screen
+            title.zh: "恢复默认空白页画面"
+            title.zh-TW: "恢復預設空白頁畫面"
             type: class-toggle
             document: ES01-EmptyState
             description: "When enabled, this reverts the empty state screen to the Obsidian default."
+            description.zh: "启用后，恢复 Obsidian 默认空白页画面。"
+            description.zh-TW: "啟用後，恢復 Obsidian 預設空白頁畫面。"
             default: false
     -
         id: typography-highlight
         title: Highlights
+        title.zh: "高亮"
+        title.zh-TW: "高亮"
         description: Options to change highlighting colours.
+        description.zh: "调整高亮颜色。"
+        description.zh-TW: "調整高亮顏色。"
         type: heading
         level: 2
         collapsed: false
     -
             id: ssopt-highlight-no-box-shadow
             title: Remove Highlight Box Shadow
+            title.zh: "移除高亮阴影"
+            title.zh-TW: "移除高亮陰影"
             type: class-toggle
             document: ET11-Highlights
             description: 'By default, Willemstad extends highlights by adding box shadows for better visual appearance. This, however, interferes with highlighting plugins such as Highlightr. This option allows for the removal of the highlighting box shadows.'
+            description.zh: "Willemstad 默认用阴影扩展高亮区域，以改善视觉效果，但这可能与 Highlightr 等高亮插件冲突。此项可移除高亮阴影。"
+            description.zh-TW: "Willemstad 預設用陰影擴充套件高亮區域，以改善視覺效果，但這可能與 Highlightr 等高亮外掛衝突。此項可移除高亮陰影。"
             default: false
     -
             id: ssopt-typ-highlight-col-original
             title: 'Use Original Highlight Colours'
+            title.zh: "使用原始高亮颜色"
+            title.zh-TW: "使用原始高亮顏色"
             type: class-toggle
             document: ET11-Highlights
             description: When enabled, this will disable the custom Willemstad highlight colours and use the original colours used for highlighting.
+            description.zh: "启用后，停用 Willemstad 自定义高亮配色，使用原始高亮颜色。"
+            description.zh-TW: "啟用後，停用 Willemstad 自訂高亮配色，使用原始高亮顏色。"
             default: false
     -
             id: col-highlight-text
             title: 'Highlighted Text Colour'
+            title.zh: "高亮文本颜色"
+            title.zh-TW: "高亮文本顏色"
             type: variable-themed-color
             document: ET11-Highlights
             description: 'Colour of the text highlighted — this defaults to black.'
+            description.zh: "高亮区域内的文本颜色，默认为黑色。"
+            description.zh-TW: "高亮區域內的文本顏色，預設為黑色。"
             opacity: false
             format: hsl
             default-light: hsl(0, 0%, 0%)
@@ -48126,10 +49152,14 @@ settings:
     -
             id: col-highlight-0
             title: 'Highlight Colour — default'
+            title.zh: "默认高亮颜色"
+            title.zh-TW: "預設高亮顏色"
             type: variable-themed-color
             document: ET11-Highlights
             notes: (highlight markdown)
             description: 'Default highlight colour (==)'
+            description.zh: "默认高亮颜色（==）。"
+            description.zh-TW: "預設高亮顏色（==）。"
             opacity: false
             format: hsl
             default-light: hsl(46, 100%, 50%)
@@ -48137,10 +49167,14 @@ settings:
     -
             id: col-highlight-1
             title: 'Highlight Colour — additional #1'
+            title.zh: "附加高亮颜色 #1"
+            title.zh-TW: "附加高亮顏色 #1"
             type: variable-themed-color
             document: ET11-Highlights
             notes: (italics + highlight markdown)
             description: 'Colour of the highlight when you use the italics markdown syntax with the highlight markdown syntax (*==).'
+            description.zh: "同时使用斜体和高亮 Markdown 语法（*==）时的高亮颜色。"
+            description.zh-TW: "同時使用斜體和高亮 Markdown 語法（*==）時的高亮顏色。"
             opacity: false
             format: hsl
             default-light: hsl(76, 100%, 50%)
@@ -48148,10 +49182,14 @@ settings:
     -
             id: col-highlight-2
             title: 'Highlight Colour — additional #2'     
+            title.zh: "附加高亮颜色 #2"
+            title.zh-TW: "附加高亮顏色 #2"
             type: variable-themed-color
             document: ET11-Highlights
             notes: (bold + highlight markdown)
             description: 'Colour of the highlight when you use the bold markdown syntax with the highlight markdown syntax (**==).'
+            description.zh: "同时使用粗体和高亮 Markdown 语法（**==）时的高亮颜色。"
+            description.zh-TW: "同時使用粗體和高亮 Markdown 語法（**==）時的高亮顏色。"
             opacity: false
             format: hsl
             default-light: hsl(166, 100%, 50%)
@@ -48159,10 +49197,14 @@ settings:
     -
             id: col-highlight-3
             title: 'Highlight Colour — additional #3'     
+            title.zh: "附加高亮颜色 #3"
+            title.zh-TW: "附加高亮顏色 #3"
             type: variable-themed-color
             document: ET11-Highlights
             notes: (bold + italics + highlight markdown)
             description: 'Colour of the highlight when you use the italics, bold and highlight markdown syntax together (***==).'
+            description.zh: "同时使用粗体、斜体和高亮 Markdown 语法（***==）时的高亮颜色。"
+            description.zh-TW: "同時使用粗體、斜體和高亮 Markdown 語法（***==）時的高亮顏色。"
             opacity: false
             format: hsl
             default-light: hsl(262, 44%, 82%)
@@ -48170,10 +49212,14 @@ settings:
     -
             id: col-highlight-0-org
             title: 'Highlight Colour (Old) — default'
+            title.zh: "旧版默认高亮颜色"
+            title.zh-TW: "舊版預設高亮顏色"
             type: variable-themed-color
             document: ET11-Highlights
             notes: (highlight markdown)
             description: 'Default highlight colour (==)'
+            description.zh: "默认高亮颜色（==）。"
+            description.zh-TW: "預設高亮顏色（==）。"
             opacity: false
             format: hsl
             default-light: hsl(60, 100%, 50%)
@@ -48181,10 +49227,14 @@ settings:
     -
             id: col-highlight-1-org
             title: 'Highlight Colour (Old) — additional #1'
+            title.zh: "旧版附加高亮颜色 #1"
+            title.zh-TW: "舊版附加高亮顏色 #1"
             type: variable-themed-color
             document: ET11-Highlights
             notes: (italics + highlight markdown)
             description: 'Colour of the highlight when you use the italics markdown syntax with the highlight markdown syntax (*==).'
+            description.zh: "同时使用斜体和高亮 Markdown 语法（*==）时的高亮颜色。"
+            description.zh-TW: "同時使用斜體和高亮 Markdown 語法（*==）時的高亮顏色。"
             opacity: false
             format: hsl
             default-light: hsl(120, 100%, 50%)
@@ -48192,10 +49242,14 @@ settings:
     -
             id: col-highlight-2-org
             title: 'Highlight Colour (Old) — additional #2'     
+            title.zh: "旧版附加高亮颜色 #2"
+            title.zh-TW: "舊版附加高亮顏色 #2"
             type: variable-themed-color
             document: ET11-Highlights
             notes: (bold + highlight markdown)
             description: 'Colour of the highlight when you use the bold markdown syntax with the highlight markdown syntax (**==).'
+            description.zh: "同时使用粗体和高亮 Markdown 语法（**==）时的高亮颜色。"
+            description.zh-TW: "同時使用粗體和高亮 Markdown 語法（**==）時的高亮顏色。"
             opacity: false
             format: hsl
             default-light: hsl(180, 100%, 50%)
@@ -48203,10 +49257,14 @@ settings:
     -
             id: col-highlight-3-org
             title: 'Highlight Colour (Old) — additional #3'
+            title.zh: "旧版附加高亮颜色 #3"
+            title.zh-TW: "舊版附加高亮顏色 #3"
             type: variable-themed-color
             document: ET11-Highlights
             notes: (bold + italics + highlight markdown)
             description: 'Colour of the highlight when you use the italics, bold and highlight markdown syntax together (***==).'
+            description.zh: "同时使用粗体、斜体和高亮 Markdown 语法（***==）时的高亮颜色。"
+            description.zh-TW: "同時使用粗體、斜體和高亮 Markdown 語法（***==）時的高亮顏色。"
             opacity: false
             format: hsl
             default-light: hsl(300, 100%, 50%)
@@ -48214,94 +49272,146 @@ settings:
     -
         id: Frontmatter
         title: "Frontmatter/Properties"
+        title.zh: "Frontmatter 与属性"
+        title.zh-TW: "Frontmatter 與屬性"
         description: "Options to manipulate and control the frontmatter. Also known as 'Properties' in Obsidian parlance."
+        description.zh: "调整 Frontmatter，即 Obsidian 中的“属性”。"
+        description.zh-TW: "調整 Frontmatter，即 Obsidian 中的“屬性”。"
         type: heading
         level: 2
         collapsed: false
     -
             id: ssopt-yaml-no-colour
             title: No YAML Colouring
+            title.zh: "禁用 YAML 配色"
+            title.zh-TW: "停用 YAML 配色"
             type: class-toggle
             document: EF01-Frontmatter
             notes: (Editing View Source Mode)
             description: "Willemstad colours the frontmatter YAML by default in Source Mode. When enabled, the frontmatter YAML will not be coloured."
+            description.zh: "Willemstad 默认在源码模式为 Frontmatter YAML 着色。启用此项后取消着色。"
+            description.zh-TW: "Willemstad 預設在原始碼模式為 Frontmatter YAML 著色。啟用此項後取消著色。"
             default: false
     -
             id: ssopt-hide-metadata-container
             title: Hide Properties in Reading Mode
+            title.zh: "在阅读模式隐藏属性"
+            title.zh-TW: "在閱讀模式隱藏屬性"
             type: class-toggle
             document: EF02-PropertiesMetadata
             notes: (Reading View)
             description: "When enabled, this hides the entire Properties block when in Reading Mode."
+            description.zh: "启用后，在阅读模式隐藏整个属性区域。"
+            description.zh-TW: "啟用後，在閱讀模式隱藏整個屬性區域。"
             default: false
     -
             id: ssopt-hide-metadata-container-lp
             title: Hide Properties in Live Preview
+            title.zh: "在实时预览隐藏属性"
+            title.zh-TW: "在即時預覽隱藏屬性"
             type: class-toggle
             document: EF02-PropertiesMetadata
             notes: (Reading View)
             description: "When enabled, this hides the entire Properties block when in Live Preview."
+            description.zh: "启用后，在实时预览隐藏整个属性区域。"
+            description.zh-TW: "啟用後，在即時預覽隱藏整個屬性區域。"
             default: false
     -
             id: ssopt-hide-properties-title
             title: Hide 'Properties' Title
+            title.zh: "隐藏“属性”标题"
+            title.zh-TW: "隱藏“屬性”標題"
             type: class-toggle
             document: EF02-PropertiesMetadata
             notes: (Reading View and Editing View Live Preview)
             description: "When enabled, this hides the 'Properties' heading above the metadata frontmatter table in both Live Preview and Reading Mode."
+            description.zh: "启用后，在实时预览和阅读模式隐藏元数据表格上方的“属性”标题。"
+            description.zh-TW: "啟用後，在即時預覽和閱讀模式隱藏後設資料表格上方的“屬性”標題。"
             default: false
     -
             id: ssopt-frontmatter-in-front
             title: Move Properties to Top of Note in Reading View
+            title.zh: "在阅读模式将属性移到笔记顶部"
+            title.zh-TW: "在閱讀模式將屬性移到筆記頂部"
             type: class-toggle
             description: "When enabled, this moves the Properties block to appear before the in-line note title in Reading Mode."
+            description.zh: "启用后，在阅读模式将属性区域移到笔记内联标题之前。"
+            description.zh-TW: "啟用後，在閱讀模式將屬性區域移到筆記內聯標題之前。"
             default: false
     -
             id: ssopt-frontmatter-in-front-lp
             title: Move Properties to Top of Note in Live Preview
+            title.zh: "在实时预览将属性移到笔记顶部"
+            title.zh-TW: "在即時預覽將屬性移到筆記頂部"
             type: class-toggle
             description: "When enabled, this moves the Properties block to appear before the in-line note title in Live Preview."
+            description.zh: "启用后，在实时预览将属性区域移到笔记内联标题之前。"
+            description.zh-TW: "啟用後，在即時預覽將屬性區域移到筆記內聯標題之前。"
             default: false
     -
             id: ssopt-properties-button-original
             title: Revert 'Add Property' Button to Default
+            title.zh: "恢复“添加属性”按钮的默认样式"
+            title.zh-TW: "恢復“新增屬性”按鈕的預設樣式"
             type: class-toggle
             document: EF02-PropertiesMetadata
             notes: (Reading View and Editing View Live Preview)
             description: "When enabled, this reverts the 'Add Property' button to its original appearance, with text and its default position."
+            description.zh: "启用后，将“添加属性”按钮恢复到原始位置与样式，并显示文字。"
+            description.zh-TW: "啟用後，將“新增屬性”按鈕恢復到原始位置與樣式，並顯示文字。"
             default: false
     -
             id: ssopt-properties-aliases-original
             title: Revert Alias Pill Style to Default
+            title.zh: "恢复别名标签的默认样式"
+            title.zh-TW: "恢復別名標籤的預設樣式"
             type: class-toggle
             document: EF02-PropertiesMetadata
             notes: (Reading View and Editing View Live Preview)
             description: "When enabled, this reverts the styling for alias pills (and other multi-select items) to the Obsidian default."
+            description.zh: "启用后，将别名标签及其他多选项目恢复为 Obsidian 默认样式。"
+            description.zh-TW: "啟用後，將別名標籤及其他多選專案恢復為 Obsidian 預設樣式。"
             default: false
     -
         id: embeds-settings
         title: Embeds
+        title.zh: "嵌入内容"
+        title.zh-TW: "嵌入內容"
         type: heading
         description: "Options to control the appearance of embedded notes and files."
+        description.zh: "调整嵌入笔记与文件的外观。"
+        description.zh-TW: "調整嵌入筆記與檔案的外觀。"
         level: 2
         collapsed: false
     -
             id: ssopt-not-seamless-embeds
             title: Disable Seamless Embeds
+            title.zh: "禁用无边框嵌入"
+            title.zh-TW: "停用無邊框嵌入"
             type: class-toggle
             description: "By default, this theme makes embedded notes seamless (no borders, padding, or scrollbars). When enabled, this reverts embeds to the standard Obsidian style, adding back borders and scrollbars."
+            description.zh: "主题默认让嵌入笔记无边框、无内边距、无滚动条。启用此项后，恢复 Obsidian 标准嵌入样式及边框、滚动条。"
+            description.zh-TW: "主題預設讓嵌入筆記無邊框、無內邊距、無捲軸。啟用此項後，恢復 Obsidian 標準嵌入樣式及邊框、捲軸。"
             default: false
     -
             id: ssopt-block-width-iframe
             title: Enable Block Widths for iFrames
+            title.zh: "启用 iFrame 内容块宽度"
+            title.zh-TW: "啟用 iFrame 內容塊寬度"
             type: class-toggle
             description: "Enables a modern, content-aware width system for iFrames (e.g. YouTube videos, Google forms). When off, tables will take Obsidian's original settings."
+            description.zh: "为 iFrame（如 YouTube 视频、Google 表单）启用根据内容调整宽度的系统。关闭时使用 Obsidian 的原始设置。"
+            description.zh-TW: "為 iFrame（如 YouTube 影片、Google 表單）啟用根據內容調整寬度的系統。關閉時使用 Obsidian 的原始設定。"
             default: false
     -
                 id: magnifier-bw-iframe
                 title: "iFrame Content Width Magnifier"
+                title.zh: "iFrame 内容宽度放大倍数"
+                title.zh-TW: "iFrame 內容寬度放大倍數"
                 type: variable-number-slider
                 description: "A multiplier to increase the base width of the iFrame content, with respect to the document's line lengths. Default is 1.5 (150%). This setting will hardly make a difference if Readable Line Lengths is turned off."
+                description.zh: "以文档行宽为基准放大 iFrame 内容宽度，默认为 1.5 倍（150%）。关闭“缩减栏宽”时，此设置的影响很小。"
+                description.zh-TW: "以文件行寬為基準放大 iFrame 內容寬度，預設為 1.5 倍（150%）。關閉“縮減欄寬”時，此設定的影響很小。"
                 min: 0.5
                 max: 3
                 step: 0.05
@@ -48309,8 +49419,12 @@ settings:
     -
                 id: ratio-bw-iframe-source
                 title: "iFrames Max Width Ratio (Live Preview)"
+                title.zh: "iFrame 最大宽度比例（实时预览）"
+                title.zh-TW: "iFrame 最大寬度比例（即時預覽）"
                 type: variable-number-slider
                 description: "The maximum width the iFrame can occupy, as a ratio of the container's width. 1 = 100%. Default is 1."
+                description.zh: "iFrame 最大宽度占容器宽度的比例。1 表示 100%，默认值为 1。"
+                description.zh-TW: "iFrame 最大寬度佔容器寬度的比例。1 表示 100%，預設值為 1。"
                 min: 0.5
                 max: 1
                 step: 0.01
@@ -48318,8 +49432,12 @@ settings:
     -
                 id: ratio-bw-iframe-reading
                 title: "iFrames Max Width Ratio (Reading Mode)"
+                title.zh: "iFrame 最大宽度比例（阅读模式）"
+                title.zh-TW: "iFrame 最大寬度比例（閱讀模式）"
                 type: variable-number-slider
                 description: "The maximum width the iFrame can occupy, as a ratio of the container's width. 1 = 100%. Default is 0.96."
+                description.zh: "iFrame 最大宽度占容器宽度的比例。1 表示 100%，默认值为 0.96。"
+                description.zh-TW: "iFrame 最大寬度佔容器寬度的比例。1 表示 100%，預設值為 0.96。"
                 min: 0.5
                 max: 1
                 step: 0.01
@@ -48327,20 +49445,32 @@ settings:
     -
                 id: aspect-ratio-bw-iframe
                 title: iFrames Aspect Ratio
+                title.zh: "iFrame 宽高比"
+                title.zh-TW: "iFrame 寬高比"
                 type: variable-text
                 description: "Sets the aspect ratio of the iFrame. Use the format 'width / height', and 'auto' for it to default to its original aspect ratio, which can be used alone, or added before or after to the 'width / height' format. Default is 'auto 16/9'."
+                description.zh: "设置 iFrame 宽高比，格式为“宽 / 高”。auto 表示使用原始宽高比，可单独使用，也可放在比例前后。默认为 auto 16/9。"
+                description.zh-TW: "設定 iFrame 寬高比，格式為“寬 / 高”。auto 表示使用原始寬高比，可單獨使用，也可放在比例前後。預設為 auto 16/9。"
                 default: 'auto 16/9'
     -
             id: ssopt-block-width-pdfembed
             title: Enable Block Widths for PDF Embeds
+            title.zh: "启用嵌入 PDF 内容块宽度"
+            title.zh-TW: "啟用嵌入 PDF 內容塊寬度"
             type: class-toggle
             description: "Enables a modern, content-aware width system for PDF embeds. When off, PDF embeds will have a simple, standard layout."
+            description.zh: "为嵌入 PDF 启用根据内容调整宽度的系统。关闭时采用简单的标准布局。"
+            description.zh-TW: "為嵌入 PDF 啟用根據內容調整寬度的系統。關閉時採用簡單的標準佈局。"
             default: false
     -
                 id: magnifier-bw-pdfembed
                 title: "PDF Embed Content Width Magnifier"
+                title.zh: "嵌入 PDF 内容宽度放大倍数"
+                title.zh-TW: "嵌入 PDF 內容寬度放大倍數"
                 type: variable-number-slider
                 description: "A multiplier to increase the base width of the PDF embed content, with respect to the document's line lengths. Default is 1.5 (150%)."
+                description.zh: "以文档行宽为基准放大嵌入 PDF 内容宽度，默认为 1.5 倍（150%）。"
+                description.zh-TW: "以文件行寬為基準放大嵌入 PDF 內容寬度，預設為 1.5 倍（150%）。"
                 min: 0.5
                 max: 3
                 step: 0.05
@@ -48348,8 +49478,12 @@ settings:
     -
                 id: ratio-bw-pdfembed-source
                 title: "PDF Embed Max Width Ratio (Live Preview)"
+                title.zh: "嵌入 PDF 最大宽度比例（实时预览）"
+                title.zh-TW: "嵌入 PDF 最大寬度比例（即時預覽）"
                 type: variable-number-slider
                 description: "The maximum width the PDF embed can occupy, as a ratio of the container's width. 1 = 100%. Default is 1."
+                description.zh: "嵌入 PDF 最大宽度占容器宽度的比例。1 表示 100%，默认值为 1。"
+                description.zh-TW: "嵌入 PDF 最大寬度佔容器寬度的比例。1 表示 100%，預設值為 1。"
                 min: 0.5
                 max: 1
                 step: 0.01
@@ -48357,8 +49491,12 @@ settings:
     -
                 id: ratio-bw-pdfembed-reading
                 title: "PDF Embed Max Width Ratio (Reading Mode)"
+                title.zh: "嵌入 PDF 最大宽度比例（阅读模式）"
+                title.zh-TW: "嵌入 PDF 最大寬度比例（閱讀模式）"
                 type: variable-number-slider
                 description: "The maximum width the PDF embed can occupy, as a ratio of the container's width. 1 = 100%. Default is 0.96."
+                description.zh: "嵌入 PDF 最大宽度占容器宽度的比例。1 表示 100%，默认值为 0.96。"
+                description.zh-TW: "嵌入 PDF 最大寬度佔容器寬度的比例。1 表示 100%，預設值為 0.96。"
                 min: 0.5
                 max: 1
                 step: 0.01
@@ -48366,16 +49504,24 @@ settings:
     -
         id: Lists
         title: Lists
+        title.zh: "列表"
+        title.zh-TW: "列表"
         description: Options to manipulate and control user-created lists.
+        description.zh: "调整笔记中的列表。"
+        description.zh-TW: "調整筆記中的列表。"
         type: heading
         level: 2
         collapsed: false
     -
             id: checkbox-radius
             title: Checkbox Radius
+            title.zh: "复选框圆角半径"
+            title.zh-TW: "核取方塊圓角半徑"
             type: variable-select
             document: EL01-ListCheckbox
             description: "This option allows one to change the radius of the checkbox in lists."
+            description.zh: "调整列表复选框的圆角半径。 选项含义：Square：方形；Small-Rounded Square：小圆角方形；Medium-Rounded Square：中圆角方形；Almost-Round：接近圆形；Round：圆形。"
+            description.zh-TW: "調整列表核取方塊的圓角半徑。 選項含義：Square：方形；Small-Rounded Square：小圓角方形；Medium-Rounded Square：中圓角方形；Almost-Round：接近圓形；Round：圓形。"
             default: 50rem
             options:
                 -
@@ -48396,36 +49542,56 @@ settings:
     -
             id: ssopt-acrs-enable
             title: Enable Alternative Checkboxes
+            title.zh: "启用扩展复选框"
+            title.zh-TW: "啟用擴充套件核取方塊"
             type: class-toggle
             document: EL-02-AltCheckboxRS
             description: "When enabled, this allows the usage of the Alternative Checkboxes Reference Set developed by Damian Korcz, also supported by other themes, in your lists."
+            description.zh: "启用后，列表可使用 Damian Korcz 制定、多个主题共同支持的扩展复选框规范（Alternative Checkboxes Reference Set）。"
+            description.zh-TW: "啟用後，列表可使用 Damian Korcz 制定、多個主題共同支援的擴充套件核取方塊規範（Alternative Checkboxes Reference Set）。"
             default: false
     -
         id: table-settings
         title: Tables
+        title.zh: "表格"
+        title.zh-TW: "表格"
         description: Options to manipulate and control Markdown tables.
+        description.zh: "调整 Markdown 表格。"
+        description.zh-TW: "調整 Markdown 表格。"
         type: heading
         level: 2
         collapsed: false
     -
             id: ssopt-block-width-tables
             title: Enable Block Widths for Tables
+            title.zh: "启用表格内容块宽度"
+            title.zh-TW: "啟用表格內容塊寬度"
             type: class-toggle
             description: "Enables a modern, content-aware block width system for tables. When off, tables will take Obsidian's original settings."
+            description.zh: "为表格启用根据内容调整宽度的系统。关闭时采用 Obsidian 的原始设置。"
+            description.zh-TW: "為表格啟用根據內容調整寬度的系統。關閉時採用 Obsidian 的原始設定。"
             default: false
     -
             id: ssopt-no-table-colours
             title: Disable Table Striping
+            title.zh: "禁用表格隔行配色"
+            title.zh-TW: "停用表格隔行配色"
             type: class-toggle
             document: PB006-BasesTables (PB006-01A)
             description: "By default, Willemstad colours alternate rows differently in Markdown tables. Enable this should you prefer Obsidian’s default look for ordinary Markdown tables."
+            description.zh: "Willemstad 默认为 Markdown 表格隔行着色。启用此项可恢复普通 Markdown 表格的 Obsidian 默认外观。"
+            description.zh-TW: "Willemstad 預設為 Markdown 表格隔行著色。啟用此項可恢復普通 Markdown 表格的 Obsidian 預設外觀。"
             default: false
 
     -
             id: ssopt-bw-table-content-fit
             title: Table Width Behavior
+            title.zh: "表格宽度策略"
+            title.zh-TW: "表格寬度策略"
             type: variable-select
             description: "Choose whether tables should shrink-to-fit their content (standard Obsidian behaviour) or be forced to fill the available width. The two Fit to Width options differ in their Live Preview look. Not requiring scrolling for the button is functionally sensible and aesthetically less pleasing, and vice versa."
+            description.zh: "选择表格宽度随内容收缩（Obsidian 默认行为），或强制填满可用宽度。两个 Fit to Width 选项在实时预览中的区别是：是否需要水平滚动才能看到操作按钮。不需要滚动时操作更方便，需要滚动时外观更整齐。 选项含义：Fit to Content：适应内容宽度；Fit to Width (Add Table Column button does not require scrolling)：填满宽度，添加列按钮无需滚动；Fit to Width (Add Table Column button requires scrolling)：填满宽度，添加列按钮需要滚动。"
+            description.zh-TW: "選擇表格寬度隨內容收縮（Obsidian 預設行為），或強制填滿可用寬度。兩個 Fit to Width 選項在即時預覽中的區別是：是否需要水平滾動才能看到操作按鈕。不需要滾動時操作更方便，需要滾動時外觀更整齊。 選項含義：Fit to Content：適應內容寬度；Fit to Width (Add Table Column button does not require scrolling)：填滿寬度，新增列按鈕無需滾動；Fit to Width (Add Table Column button requires scrolling)：填滿寬度，新增列按鈕需要滾動。"
             allowEmpty: false
             default: '0'
             options:
@@ -48441,8 +49607,12 @@ settings:
     -
             id: magnifier-bw-table
             title: "Tables Content Width Magnifier"
+            title.zh: "表格内容宽度放大倍数"
+            title.zh-TW: "表格內容寬度放大倍數"
             type: variable-number-slider
             description: "A multiplier to increase the base width of the table content, with respect to the document's line lengths. Default is 1.5 (150%). This setting will hardly make a difference if Readable Line Lengths is turned off."
+            description.zh: "以文档行宽为基准放大表格内容宽度，默认为 1.5 倍（150%）。关闭“缩减栏宽”时，此设置的影响很小。"
+            description.zh-TW: "以文件行寬為基準放大表格內容寬度，預設為 1.5 倍（150%）。關閉“縮減欄寬”時，此設定的影響很小。"
             min: 0.5
             max: 3
             step: 0.05
@@ -48450,8 +49620,12 @@ settings:
     -
             id: ratio-bw-table-source
             title: "Tables Max Width Ratio (Live Preview)"
+            title.zh: "表格最大宽度比例（实时预览）"
+            title.zh-TW: "表格最大寬度比例（即時預覽）"
             type: variable-number-slider
             description: "The maximum width the table can occupy, as a ratio of the container's width. 1 = 100% (whole container width). Default is 1."
+            description.zh: "表格最大宽度占容器宽度的比例。1 表示 100%（整个容器宽度），默认值为 1。"
+            description.zh-TW: "表格最大寬度佔容器寬度的比例。1 表示 100%（整個容器寬度），預設值為 1。"
             min: 0.5
             max: 1
             step: 0.01
@@ -48459,8 +49633,12 @@ settings:
     -
             id: ratio-bw-table-reading
             title: "Tables Max Width Ratio (Reading Mode)"
+            title.zh: "表格最大宽度比例（阅读模式）"
+            title.zh-TW: "表格最大寬度比例（閱讀模式）"
             type: variable-number-slider
             description: "The maximum width the table can occupy, as a ratio of the container's width. 1 = 100% (whole container width). Default is 0.96 (96%)."
+            description.zh: "表格最大宽度占容器宽度的比例。1 表示 100%（整个容器宽度），默认值为 0.96（96%）。"
+            description.zh-TW: "表格最大寬度佔容器寬度的比例。1 表示 100%（整個容器寬度），預設值為 0.96（96%）。"
             min: 0.5
             max: 1
             step: 0.01
@@ -48468,36 +49646,56 @@ settings:
     -
         id: bases-settings
         title: Bases
+        title.zh: "数据库（Bases）"
+        title.zh-TW: "資料庫（Bases）"
         type: heading
         description: Options to manipulate and control the Bases core plugin.
+        description.zh: "调整数据库（Bases）核心插件。"
+        description.zh-TW: "調整資料庫（Bases）核心外掛。"
         level: 2
         collapsed: false
     -
             id: ssopt-block-width-bases
             title: "Enable Block Widths for Bases"
+            title.zh: "启用数据库内容块宽度"
+            title.zh-TW: "啟用資料庫內容塊寬度"
             type: class-toggle
             description: "Enables a modern, content-aware block width system for Bases."
+            description.zh: "为数据库启用根据内容调整宽度的系统。"
+            description.zh-TW: "為資料庫啟用根據內容調整寬度的系統。"
             default: false
     -
             id: ssopt-standard-bases-colours
             title: Revert to Standard Bases Appearance
+            title.zh: "恢复数据库默认外观"
+            title.zh-TW: "恢復資料庫預設外觀"
             type: class-toggle
             document: PB006-BasesTables (PB006-01B)
             description: "Reverts the Bases core plugin to its stock colour scheme instead of Willemstad’s palette."
+            description.zh: "将数据库核心插件恢复为原始配色，不再使用 Willemstad 配色。"
+            description.zh-TW: "將資料庫核心外掛恢復為原始配色，不再使用 Willemstad 配色。"
             default: false
     -
             id: ssopt-bases-no-edit
             title: "Non-Editable and Read-Only Bases in Reading Mode"
+            title.zh: "在阅读模式将数据库设为只读"
+            title.zh-TW: "在閱讀模式將資料庫設為只讀"
             type: class-toggle
             document: PB006-BasesTables (PB006-02)
             description: "By default in Obsidian, Bases are editable in Reading Mode. Enable this to turn off editing in Reading Mode."
+            description.zh: "Obsidian 默认允许在阅读模式编辑数据库。启用此项后，阅读模式下的数据库不可编辑。"
+            description.zh-TW: "Obsidian 預設允許在閱讀模式編輯資料庫。啟用此項後，閱讀模式下的資料庫不可編輯。"
             default: false
 
     -
             id: magnifier-bw-bases
             title: "Bases Content Width Magnifier"
+            title.zh: "数据库内容宽度放大倍数"
+            title.zh-TW: "資料庫內容寬度放大倍數"
             type: variable-number-slider
             description: "A multiplier to increase the base width of the Bases content, with respect to the document's line lengths. Default is 1.5 (150%). This setting will hardly make a difference if Readable Line Lengths is turned off."
+            description.zh: "以文档行宽为基准放大数据库内容宽度，默认为 1.5 倍（150%）。关闭“缩减栏宽”时，此设置的影响很小。"
+            description.zh-TW: "以文件行寬為基準放大數據庫內容寬度，預設為 1.5 倍（150%）。關閉“縮減欄寬”時，此設定的影響很小。"
             min: 0.5
             max: 3
             step: 0.05
@@ -48505,8 +49703,12 @@ settings:
     -
             id: ratio-bw-bases-source
             title: "Bases Max Width Ratio (Live Preview)"
+            title.zh: "数据库最大宽度比例（实时预览）"
+            title.zh-TW: "資料庫最大寬度比例（即時預覽）"
             type: variable-number-slider
             description: "The maximum width Bases can occupy, as a ratio of the container's width. 1 = 100% (whole container width). Default is 1."
+            description.zh: "数据库最大宽度占容器宽度的比例。1 表示 100%（整个容器宽度），默认值为 1。"
+            description.zh-TW: "資料庫最大寬度佔容器寬度的比例。1 表示 100%（整個容器寬度），預設值為 1。"
             min: 0.5
             max: 1
             step: 0.01
@@ -48514,8 +49716,12 @@ settings:
     -
             id: ratio-bw-bases-reading
             title: "Bases Max Width Ratio (Reading Mode)"
+            title.zh: "数据库最大宽度比例（阅读模式）"
+            title.zh-TW: "資料庫最大寬度比例（閱讀模式）"
             type: variable-number-slider
             description: "The maximum width Bases can occupy, as a ratio of the container's width. 1 = 100% (whole container width). Default is 0.96 (96%)."
+            description.zh: "数据库最大宽度占容器宽度的比例。1 表示 100%（整个容器宽度），默认值为 0.96（96%）。"
+            description.zh-TW: "資料庫最大寬度佔容器寬度的比例。1 表示 100%（整個容器寬度），預設值為 0.96（96%）。"
             min: 0.5
             max: 1
             step: 0.01
@@ -48523,57 +49729,91 @@ settings:
     -
         id: canvas-settings
         title: Canvas
+        title.zh: "白板（Canvas）"
+        title.zh-TW: "白板（Canvas）"
         type: heading
         description: 'Options to manipulate items in the Canvas.'
+        description.zh: "调整白板中的元素。"
+        description.zh-TW: "調整白板中的元素。"
         level: 2
         collapsed: false
     -
             id: ssopt-canvas-hide-node-labels
             title: Hide Node Labels
+            title.zh: "隐藏节点标签"
+            title.zh-TW: "隱藏節點標籤"
             type: class-toggle
             description: "When enabled, hides the labels/titles on individual nodes (files/cards) in the Canvas."
+            description.zh: "启用后，隐藏白板中单个节点（文件或卡片）的标签或标题。"
+            description.zh-TW: "啟用後，隱藏白板中單個節點（檔案或卡片）的標籤或標題。"
             default: false
     -
             id: ssopt-canvas-hide-group-labels
             title: Hide Group Labels
+            title.zh: "隐藏分组标签"
+            title.zh-TW: "隱藏分組標籤"
             type: class-toggle
             description: "When enabled, hides the labels on groups in the Canvas."
+            description.zh: "启用后，隐藏白板分组标签。"
+            description.zh-TW: "啟用後，隱藏白板分組標籤。"
             default: false
     -
             id: canvas-node-font-size
             title: Node Label Font Size
+            title.zh: "节点标签字号"
+            title.zh-TW: "節點標籤字級"
             type: variable-text
             description: "Sets the font size for labels on individual nodes (files/cards). Accepts any valid CSS unit (e.g., 1em, 14px, 1.2rem)."
+            description.zh: "设置单个节点（文件或卡片）的标签字号。接受有效的 CSS 单位，例如 1em、14px 或 1.2rem。"
+            description.zh-TW: "設定單個節點（檔案或卡片）的標籤字級。接受有效的 CSS 單位，例如 1em、14px 或 1.2rem。"
             default: '1em'
     -
             id: canvas-group-font-size
             title: Group Label Font Size
+            title.zh: "分组标签字号"
+            title.zh-TW: "分組標籤字級"
             type: variable-text
             description: "Sets the font size for labels on groups. Accepts any valid CSS unit."
+            description.zh: "设置分组标签字号。接受有效的 CSS 单位。"
+            description.zh-TW: "設定分組標籤字級。接受有效的 CSS 單位。"
             default: '1.5em'
     -
             id: canvas-background
             title: Canvas Background Colour
+            title.zh: "白板背景色"
+            title.zh-TW: "白板背景色"
             type: variable-text
             description: "Sets the background colour of the Canvas. Accepts any valid CSS colour format (e.g., hex, rgb, hsl, oklch, var(--some-variable))."
+            description.zh: "设置白板背景色。接受有效的 CSS 颜色格式，例如 hex、rgb、hsl、oklch 或 var(--some-variable)。"
+            description.zh-TW: "設定白板背景色。接受有效的 CSS 顏色格式，例如 hex、rgb、hsl、oklch 或 var(--some-variable)。"
             default: 'var(--background-primary)'
     -
             id: canvas-settings-grid
             title: Grid and Dots
+            title.zh: "网格与圆点"
+            title.zh-TW: "網格與圓點"
             type: heading
             level: 3
             collapsed: false
     -
                 id: canvas-dot-pattern
                 title: Canvas Background Dot Colour
+                title.zh: "白板背景圆点颜色"
+                title.zh-TW: "白板背景圓點顏色"
                 type: variable-text
                 description: "Sets the colour of the dots in the Canvas background. Accepts any valid CSS colour format."
+                description.zh: "设置白板背景圆点颜色。接受有效的 CSS 颜色格式。"
+                description.zh-TW: "設定白板背景圓點顏色。接受有效的 CSS 顏色格式。"
                 default: 'var(--color-base-30)'
     -
                 id: canvas-dot-size
                 title: Canvas Background Dot Size
+                title.zh: "白板背景圆点大小"
+                title.zh-TW: "白板背景圓點大小"
                 type: variable-number-slider
                 description: "Controls the size of the dots in the Canvas background. Obsidian's default is 0.7. Change this to zero to get a Heptabase-like background."
+                description.zh: "控制白板背景圆点大小。Obsidian 默认值为 0.7，设为 0 可获得类似 Heptabase 的背景。"
+                description.zh-TW: "控制白板背景圓點大小。Obsidian 預設值為 0.7，設為 0 可獲得類似 Heptabase 的背景。"
                 format: ""
                 min: 0
                 max: 2
@@ -48582,38 +49822,58 @@ settings:
     -
         id: pdf-viewer-settings
         title: PDF Viewer
+        title.zh: "PDF 阅读器"
+        title.zh-TW: "PDF 閱讀器"
         type: heading
         description: 'Options to manipulate and control the PDF viewer. For PDF embeds, please refer to the Embeds section above.'
+        description.zh: "调整 PDF 阅读器。嵌入 PDF 的设置请见上方“嵌入内容”区域。"
+        description.zh-TW: "調整 PDF 閱讀器。嵌入 PDF 的設定請見上方“嵌入內容”區域。"
         level: 2
         collapsed: false
     -
             id: ssopt-invert-pdf-dark
             title: Invert PDF Colours in Dark Mode
+            title.zh: "在深色模式反转 PDF 颜色"
+            title.zh-TW: "在深色模式反轉 PDF 顏色"
             type: class-toggle
             description: "When in dark mode, this inverts the colors of embedded PDFs to make them easier to read. Please note that this option is very rudimentary and there are no good CSS options given the limitations of accessing colours within PDF in Obsidian. You are strongly recommended to use Obsidian's 'Adapt to Theme' option, accessible via the PDF toolbar, first, and only resort to this should it fail to work."
+            description.zh: "在深色模式下反转嵌入 PDF 的颜色，以便阅读。此功能较为基础，且 Obsidian 的 PDF 内部颜色难以通过 CSS 精细控制。建议先使用 PDF 工具栏中的“适应主题”（Adapt to Theme），无效时再尝试此选项。"
+            description.zh-TW: "在深色模式下反轉嵌入 PDF 的顏色，以便閱讀。此功能較為基礎，且 Obsidian 的 PDF 內部顏色難以通過 CSS 精細控制。建議先使用 PDF 工具列中的“適應主題”（Adapt to Theme），無效時再嘗試此選項。"
             default: false
     -
         id: ancillary-editor-options
         title: Ancillary Editor Options
+        title.zh: "编辑器其他选项"
+        title.zh-TW: "編輯器其他選項"
         description: Options to manipulate and control other aspects of the editor.
+        description.zh: "调整编辑器的其他方面。"
+        description.zh-TW: "調整編輯器的其他方面。"
         type: heading
         level: 2
         collapsed: false
     -
             id: ssopt-show-urls
             title: Show URLs By Default
+            title.zh: "默认显示 URL"
+            title.zh-TW: "預設顯示 URL"
             type: class-toggle
             document: X101
             notes: (For Source Mode only)
             description: "Courtesy of Chris (Shimmering Focus), Willemstad has a feature that hides the URLs by default. When enabled, the URLs will be visible by default."
+            description.zh: "Willemstad 采用 Chris（Shimmering Focus）提供的默认隐藏 URL 功能。启用此项后，URL 默认可见。"
+            description.zh-TW: "Willemstad 採用 Chris（Shimmering Focus）提供的預設隱藏 URL 功能。啟用此項後，URL 預設可見。"
             default: false
     -
             id: ssopt-overflow-hack
             title: Overflow Fix
+            title.zh: "修复内容溢出"
+            title.zh-TW: "修復內容溢位"
             type: class-toggle
             document: X101
             notes: "(For Reading Mode only)"
             description: "Courtesy of SlRvB (ITS Theme), this is a fix for possible overflow issues in the editor in Reading Mode, which is especially obvious when HTML Aside and Infobox are aligned to the left. When enabled, the overflow issue will be fixed."
+            description.zh: "SlRvB（ITS Theme）提供的阅读模式溢出修复，对左浮动的 HTML 旁注和信息框尤其有用。启用后修复可能出现的内容溢出。"
+            description.zh-TW: "SlRvB（ITS Theme）提供的閱讀模式溢位修復，對左浮動的 HTML 旁註和資訊框尤其有用。啟用後修復可能出現的內容溢位。"
             default: false
 */
 
@@ -48624,81 +49884,125 @@ settings:
     -
         id: info-cssclasses-elsewhere
         title: Note on Global CSSClass
+        title.zh: "全局 CSSClass 说明"
+        title.zh-TW: "全域 CSSClass 說明"
         type: class-toggle
         description: "Please note that global CSSClasses (CSSClasses that affect the entire page, rather than just specific elements), are controlled in their separate Style Setting categories prefixed with 'Willemstad CSSClass'."
+        description.zh: "影响整个页面的全局 CSSClass 在独立的 Style Settings 分组中配置，分组以 Willemstad CSSClass 为前缀。"
+        description.zh-TW: "影響整個頁面的全域 CSSClass 在獨立的 Style Settings 分組中配置，分組以 Willemstad CSSClass 為字首。"
         markdown: true
     -
         id: callouts-settings
         title: Callouts
+        title.zh: "标注（Callouts）"
+        title.zh-TW: "標註（Callouts）"
         type: heading
         level: 2
         collapsed: false
     -
             id: info-callouts
             title: For more information about each specific callout type, please refer to the documentation links below.
+            title.zh: "各类标注的详细说明见下方文档链接。"
+            title.zh-TW: "各類標註的詳細說明見下方文件連結。"
             type: info-text
             markdown: true
     -
             id: callouts-metadata-classes
             title: Global Metadata Classes
+            title.zh: "全局元数据类"
+            title.zh-TW: "全域後設資料類"
             description: 'Metadata classes can be appended to the end of a callout syntax to produce certain effects. Replace "metadata-classes" in the following syntax, which is copyable, to test things out.'
+            description.zh: "在标注语法末尾添加元数据类，可获得不同效果。下方语法可复制使用，将 metadata-classes 替换为所需的类即可。"
+            description.zh-TW: "在標註語法末尾新增後設資料類，可獲得不同效果。下方語法可複製使用，將 metadata-classes 替換為所需的類即可。"
             type: heading
             level: 3
             collapsed: false
     -
                 id: documentation-callouts-metadata
                 title: Documentation for Global Metadata Classes
+                title.zh: "全局元数据类文档"
+                title.zh-TW: "全域後設資料類文件"
                 type: info-text
                 document: EW11-C-Metadata
                 description: "[Docs](https://willemstad.cc/Features/Callouts/Global+Metadata+Classes)"
+                description.zh: "[文档](https://willemstad.cc/Features/Callouts/Global+Metadata+Classes)"
+                description.zh-TW: "[文件](https://willemstad.cc/Features/Callouts/Global+Metadata+Classes)"
                 markdown: true
     -
                 id: syntax-callouts-metadata
                 title: Syntax for Global Metadata Classes
+                title.zh: "全局元数据类语法"
+                title.zh-TW: "全域後設資料類語法"
                 type: class-toggle
                 document: EW11-C-Metadata
                 description: ">[!callout-class|metadata-class]"
+                description.zh: ">[!callout-class|metadata-class]"
+                description.zh-TW: ">[!callout-class|metadata-class]"
                 default: false
     -
                 id: syntax-type-callouts-metadata
                 title: Types of Global Metadata Classes
+                title.zh: "全局元数据类类型"
+                title.zh-TW: "全域後設資料類型別"
                 type: class-toggle
                 document: EW11-C-Metadata
                 description: no-t, no-title; opp, opposite; no-bg, no-background; no-s, no-style; mono, monospace; fl, float-l, float-left, left; fr, float-r, float-right, right; no-m-t, no-margin-top; no-m-b, no-margin-btm, no-margin-bottom; no-m-l, no-margin-left; no-m-r, no-margin-right;
+                description.zh: "可用类（保持英文拼写）：no-t、no-title 隐藏标题；opp、opposite 使用相反配色；no-bg、no-background 无背景；no-s、no-style 无样式；mono、monospace 等宽字体；fl、float-l、float-left、left 左浮动；fr、float-r、float-right、right 右浮动；no-m-t、no-margin-top 移除上外边距；no-m-b、no-margin-btm、no-margin-bottom 移除下外边距；no-m-l、no-margin-left 移除左外边距；no-m-r、no-margin-right 移除右外边距。"
+                description.zh-TW: "可用類（保持英文拼寫）：no-t、no-title 隱藏標題；opp、opposite 使用相反配色；no-bg、no-background 無背景；no-s、no-style 無樣式；mono、monospace 等寬字型；fl、float-l、float-left、left 左浮動；fr、float-r、float-right、right 右浮動；no-m-t、no-margin-top 移除上外邊距；no-m-b、no-margin-btm、no-margin-bottom 移除下外邊距；no-m-l、no-margin-left 移除左外邊距；no-m-r、no-margin-right 移除右外邊距。"
                 default: false
     -
             id: callouts-standard
             title: Standard Callouts
+            title.zh: "标准标注"
+            title.zh-TW: "標準標註"
             description: To use standard callouts, use the following syntax below, which is also copyable for your own convenience. The types of standard callouts available in Willemstad is also listed below.
+            description.zh: "使用下方可复制的语法创建标准标注。Willemstad 支持的标准标注类型也列于下方。"
+            description.zh-TW: "使用下方可複製的語法建立標準標註。Willemstad 支援的標準標註型別也列於下方。"
             type: heading
             level: 3
             collapsed: false
     -
                 id: documentation-callouts-standard
                 title: Documentation for Standard Callouts
+                title.zh: "标准标注文档"
+                title.zh-TW: "標準標註文件"
                 type: info-text
                 document: EW12-C-Standard
                 description: "[Docs](https://willemstad.cc/Features/Callouts/Callouts)"
+                description.zh: "[文档](https://willemstad.cc/Features/Callouts/Callouts)"
+                description.zh-TW: "[文件](https://willemstad.cc/Features/Callouts/Callouts)"
                 markdown: true
     -
                 id: syntax-callouts-standard
                 title: Syntax for Standard Callouts
+                title.zh: "标准标注语法"
+                title.zh-TW: "標準標註語法"
                 type: class-toggle
                 document: EW12-C-Standard
                 description: ">[!note]"
+                description.zh: ">[!note]"
+                description.zh-TW: ">[!note]"
                 default: false
     -
                 id: syntax-type-callouts-standard
                 title: Types of Standard Callouts
+                title.zh: "标准标注类型"
+                title.zh-TW: "標準標註型別"
                 type: class-toggle
                 document: EW12-C-Standard
                 description: note; abstract, summary, tldr; info, todo; tip, hint; check, done; question, help, faq; warning, caution, attention; failure, fail, missing; danger, error; bug; example; quote, cite; file, attachment; phone; email, mail; goal; success; important; code; positive, plus; negative, minus
+                description.zh: "可用类型（保持英文拼写）：note 笔记；abstract、summary、tldr 摘要；info、todo 信息或待办；tip、hint 提示；check、done 完成；question、help、faq 问题；warning、caution、attention 警告；failure、fail、missing 失败或缺失；danger、error 危险或错误；bug 缺陷；example 示例；quote、cite 引用；file、attachment 文件或附件；phone 电话；email、mail 邮件；goal 目标；success 成功；important 重要；code 代码；positive、plus 正向；negative、minus 负向。"
+                description.zh-TW: "可用型別（保持英文拼寫）：note 筆記；abstract、summary、tldr 摘要；info、todo 資訊或待辦；tip、hint 提示；check、done 完成；question、help、faq 問題；warning、caution、attention 警告；failure、fail、missing 失敗或缺失；danger、error 危險或錯誤；bug 缺陷；example 示例；quote、cite 引用；file、attachment 檔案或附件；phone 電話；email、mail 郵件；goal 目標；success 成功；important 重要；code 程式碼；positive、plus 正向；negative、minus 負向。"
                 default: false
     -
             id: ssopt-callout-style
             title: Callout Style
+            title.zh: "标注样式"
+            title.zh-TW: "標註樣式"
             type: variable-select
             description: "Choose the visual style for callouts. 'Willemstad' is the default theme style. To use Obsidian's standard styling, please use the 'Revent to Original Obsidian Styling on Standard Callouts' toggle below this option."
+            description.zh: "选择标注外观。Willemstad 为默认主题样式；如需 Obsidian 标准样式，请启用下方“恢复标准标注的 Obsidian 原始样式”。"
+            description.zh-TW: "選擇標註外觀。Willemstad 為預設主題樣式；如需 Obsidian 標準樣式，請啟用下方“恢復標準標註的 Obsidian 原始樣式”。"
             allowEmpty: false
             default: '0'
             options:
@@ -48711,21 +50015,33 @@ settings:
     -
                 id: ssopt-callout-standard
                 title: Revert to Original Obsidian Styling on Standard Callouts
+                title.zh: "恢复标准标注的 Obsidian 原始样式"
+                title.zh-TW: "恢復標準標註的 Obsidian 原始樣式"
                 type: class-toggle
                 document: EW01-CFixes
                 description: "Willemstad by default styles the callouts, toggle this in order to disable this and return to Obsidian's standard callouts appearance."
+                description.zh: "Willemstad 默认自定义标注样式。启用此项可恢复 Obsidian 标准标注外观。"
+                description.zh-TW: "Willemstad 預設自訂標註樣式。啟用此項可恢復 Obsidian 標準標註外觀。"
                 default: false
     -
                 id: ssopt-callout-no-hover
                 title: "Disable Callout Border Hover/Always Show Callout Border"
+                title.zh: "始终显示标注边框（禁用悬停后显示）"
+                title.zh-TW: "始終顯示標註邊框（停用懸停後顯示）"
                 type: class-toggle
                 description: "By default, the colored left border on callouts only appears on hover. When enabled, this makes the border permanently visible. If you do not want a border, toggle this to always show the border and set the callout border width below to zero."
+                description.zh: "标注左侧彩色边框默认仅在悬停时显示。启用后始终显示。如需完全隐藏边框，请启用此项并将下方边框宽度设为 0。"
+                description.zh-TW: "標註左側彩色邊框預設僅在懸停時顯示。啟用後始終顯示。如需完全隱藏邊框，請啟用此項並將下方邊框寬度設為 0。"
                 default: false
     -
                 id: callout-border-left-extra
                 title: "Callout Border Width (Left)"
+                title.zh: "标注边框宽度（左侧）"
+                title.zh-TW: "標註邊框寬度（左側）"
                 type: variable-number-slider
                 description: "Controls the additional thickness of the colored left border on callouts, added to the base width. Set this and the base width to zero to hide the border completely. Default is 5px."
+                description.zh: "设置标注左侧彩色边框在基础宽度之上增加的厚度。将此值和基础宽度都设为 0，可完全隐藏边框。默认为 5px。"
+                description.zh-TW: "設定標註左側彩色邊框在基礎寬度之上增加的厚度。將此值和基礎寬度都設為 0，可完全隱藏邊框。預設為 5px。"
                 format: "px"
                 min: 0
                 max: 10
@@ -48734,35 +50050,53 @@ settings:
     -
                 id: callout-border-base-width-override
                 title: "Callout Border Width (Base)"
+                title.zh: "标注边框宽度（基础）"
+                title.zh-TW: "標註邊框寬度（基礎）"
                 type: variable-text
                 description: "Overrides the base border width for callouts. Accepts any valid CSS length (e.g., 1px, 0.25rem, 0) or variables that resolves to a length. The default is set in a way that the override will take the values of any presets set by the callout."
+                description.zh: "覆盖标注的基础边框宽度。接受有效的 CSS 长度（如 1px、0.25rem、0）或表示长度的变量。默认值会沿用标注预设的边框宽度。"
+                description.zh-TW: "覆蓋標註的基礎邊框寬度。接受有效的 CSS 長度（如 1px、0.25rem、0）或表示長度的變數。預設值會沿用標註預設的邊框寬度。"
                 default: 'var(--callout-border-base-width-preset)'
     -
             id: callouts-infobox
             title: Infobox Callouts
+            title.zh: "信息框标注（Infobox）"
+            title.zh-TW: "資訊框標註（Infobox）"
             type: heading
             level: 3
             collapsed: false
     -
                 id: documentation-callouts-infobox
                 title: Documentation for Infobox Callouts
+                title.zh: "信息框标注文档"
+                title.zh-TW: "資訊框標註文件"
                 type: info-text
                 document: EW24-C-Infobox
                 description: "[Docs](https://willemstad.cc/Features/Callouts/Infobox)"
+                description.zh: "[文档](https://willemstad.cc/Features/Callouts/Infobox)"
+                description.zh-TW: "[文件](https://willemstad.cc/Features/Callouts/Infobox)"
                 markdown: true
     -
                 id: syntax-callouts-infobox
                 title: Syntax for Infobox Callouts
+                title.zh: "信息框标注语法"
+                title.zh-TW: "資訊框標註語法"
                 type: class-toggle
                 document: EW24-C-Infobox
                 description: ">[!infobox]"
+                description.zh: ">[!infobox]"
+                description.zh-TW: ">[!infobox]"
                 default: false
     -
                 id: infobox-title-font-size
                 title: Title Size of Infobox Callouts 
+                title.zh: "信息框标注标题字号"
+                title.zh-TW: "資訊框標註標題字級"
                 type: variable-select
                 document: EW24-C-Infobox
                 description: "Changes the font size of the infobox title, using the heading sizes defined in Willemstad."
+                description.zh: "使用 Willemstad 定义的标题字号，设置标注信息框标题的大小。 选项含义：Heading 1 (H1)：1 级标题；Heading 2 (H2)：2 级标题；Heading 3 (H3)：3 级标题；Heading 4 (H4)：4 级标题；Heading 5 (H5)：5 级标题；Heading 6 (H6)：6 级标题。"
+                description.zh-TW: "使用 Willemstad 定義的標題字級，設定標註資訊框標題的大小。 選項含義：Heading 1 (H1)：1 級標題；Heading 2 (H2)：2 級標題；Heading 3 (H3)：3 級標題；Heading 4 (H4)：4 級標題；Heading 5 (H5)：5 級標題；Heading 6 (H6)：6 級標題。"
                 default: var(--h2-size)
                 options:
                     -
@@ -48786,9 +50120,13 @@ settings:
     -
                 id: infobox-max-width
                 title: Maximum Width of Infobox Callouts 
+                title.zh: "信息框标注最大宽度"
+                title.zh-TW: "資訊框標註最大寬度"
                 type: variable-number-slider
                 document: EW24-C-Infobox
                 description: "Sets the maximum width of the infobox relative to the pane size. The infobox will not grow larger than this percentage."
+                description.zh: "设置标注信息框相对于面板的最大宽度百分比，信息框不会超过此值。"
+                description.zh-TW: "設定標註資訊框相對於面板的最大寬度百分比，資訊框不會超過此值。"
                 default: 50
                 min: 10
                 max: 75
@@ -48797,90 +50135,136 @@ settings:
     -
                 id: infobox-set-width
                 title: Ideal Width of Infobox Callouts
+                title.zh: "信息框标注理想宽度"
+                title.zh-TW: "資訊框標註理想寬度"
                 type: variable-text
                 document: EW24-C-Infobox
                 description: "Sets the ideal target width of the infobox. If this value is larger than the 'Maximum Width of Infobox Callouts', the maximum width will take precedence. You can use any valid CSS unit, such as 500px, 50%, 40vw, 30em, etc."
+                description.zh: "设置信息框的理想宽度。如果超过“信息框标注最大宽度”，则以最大宽度为准。接受有效的 CSS 单位，如 500px、50%、40vw 或 30em。"
+                description.zh-TW: "設定資訊框的理想寬度。如果超過“資訊框標註最大寬度”，則以最大寬度為準。接受有效的 CSS 單位，如 500px、50%、40vw 或 30em。"
                 default: '50%'
     -
             id: callouts-aside
             title: Aside Callouts
+            title.zh: "旁注标注（Aside）"
+            title.zh-TW: "旁註標註（Aside）"
             type: heading
             level: 3
             collapsed: false
     -
                 id: documentation-callouts-aside
                 title: Documentation for Aside Callouts
+                title.zh: "旁注标注文档"
+                title.zh-TW: "旁註標註文件"
                 type: info-text
                 document: EW23-C-Aside
                 description: "[Docs](https://willemstad.cc/Features/Callouts/Aside)"
+                description.zh: "[文档](https://willemstad.cc/Features/Callouts/Aside)"
+                description.zh-TW: "[文件](https://willemstad.cc/Features/Callouts/Aside)"
                 markdown: true
     -
                 id: syntax-callouts-aside
                 title: Syntax for Aside Callouts
+                title.zh: "旁注标注语法"
+                title.zh-TW: "旁註標註語法"
                 type: class-toggle
                 document: EW23-C-Aside
                 description: ">[!aside]"
+                description.zh: ">[!aside]"
+                description.zh-TW: ">[!aside]"
                 default: false
     -
                 id: ssopt-callout-aside-float-left
                 title: Float Aside Callouts Left
+                title.zh: "旁注标注向左浮动"
+                title.zh-TW: "旁註標註向左浮動"
                 type: class-toggle
                 description: "The aside callouts float right by default. Toggle this option to change the float to left by default. You can float an aside left/right individually via global metadata classes 'fl', 'float-l', 'float-left' for left, and 'fr', 'float-r', 'float-right' for right."
+                description.zh: "旁注标注默认向右浮动。启用此项将默认方向改为左侧。单个旁注仍可用 fl、float-l、float-left 向左浮动，或 fr、float-r、float-right 向右浮动。"
+                description.zh-TW: "旁註標註預設向右浮動。啟用此項將預設方向改為左側。單個旁註仍可用 fl、float-l、float-left 向左浮動，或 fr、float-r、float-right 向右浮動。"
                 default: false
     -
             id: callouts-columns
             title: Columns Callouts
+            title.zh: "分栏标注（Columns）"
+            title.zh-TW: "分欄標註（Columns）"
             type: heading
             level: 3
             collapsed: false
     -
                 id: documentation-callouts-columns
                 title: Documentation for Columns Callouts
+                title.zh: "分栏标注文档"
+                title.zh-TW: "分欄標註文件"
                 type: info-text
                 document: EW13-C-Columns
                 description: "[Docs](https://willemstad.cc/Features/Callouts/Columns)"
+                description.zh: "[文档](https://willemstad.cc/Features/Callouts/Columns)"
+                description.zh-TW: "[文件](https://willemstad.cc/Features/Callouts/Columns)"
                 markdown: true
     -
                 id: syntax-callouts-columns
                 title: Syntax for Columns Callouts
+                title.zh: "分栏标注语法"
+                title.zh-TW: "分欄標註語法"
                 type: class-toggle
                 document: EW13-C-Columns
                 description: ">[!columns]"
+                description.zh: ">[!columns]"
+                description.zh-TW: ">[!columns]"
                 default: false
     -
                 id: syntax-callouts-columns-metadata
                 title: Syntax for Columns Metadata Classes
+                title.zh: "分栏元数据类语法"
+                title.zh-TW: "分欄後設資料類語法"
                 type: info-text
                 document: EW11-C-Metadata
                 description: ">[!columns|metadata-class]
                 >
                 >> [!callout-class|metadata-class]"
+                description.zh: ">[!columns|metadata-class] > >> [!callout-class|metadata-class]"
+                description.zh-TW: ">[!columns|metadata-class] > >> [!callout-class|metadata-class]"
                 default: false
     -
                 id: syntax-type-callouts-columns-metadata
                 title: Types of Columns Metadata Classes
+                title.zh: "分栏元数据类类型"
+                title.zh-TW: "分欄後設資料類型別"
                 type: class-toggle
                 document: EW13-C-Columns
                 description: w1, width-1; w2, width-2; w3, width-3; w4, width-4; w5, width-5;
+                description.zh: "列宽元数据类（保持英文拼写）：w1、width-1；w2、width-2；w3、width-3；w4、width-4；w5、width-5。"
+                description.zh-TW: "列寬後設資料類（保持英文拼寫）：w1、width-1；w2、width-2；w3、width-3；w4、width-4；w5、width-5。"
                 default: false
     -
                 id: callout-columns-margin-top
                 title: Top Margin of Column Callouts
+                title.zh: "分栏标注顶部外边距"
+                title.zh-TW: "分欄標註頂部外邊距"
                 type: variable-text
                 document: EW24-C-Columns
                 description: "Sets the margin above children callouts to create vertical space between the children callouts and the column callout title. You can use any valid CSS unit, or valid variables, such as 20px, 1.5em, 2vh, etc."
+                description.zh: "设置子标注顶部外边距，在子标注与分栏标注标题之间留出垂直空间。接受有效的 CSS 单位或变量，如 20px、1.5em 或 2vh。"
+                description.zh-TW: "設定子標註頂部外邊距，在子標註與分欄標註標題之間留出垂直空間。接受有效的 CSS 單位或變數，如 20px、1.5em 或 2vh。"
                 default: "var(--margin-callout)"
     -
             id: callouts-images
             title: Image Callouts
+            title.zh: "图片标注"
+            title.zh-TW: "圖片標註"
             type: heading
             level: 3
             collapsed: false
     -
                 id: ssopt-callouts-images-display
                 title: Default Title Display for Image Callouts
+                title.zh: "图片标注默认标题显示方式"
+                title.zh-TW: "圖片標註預設標題顯示方式"
                 type: variable-select
                 description: "Controls whether the title is globally hidden for [!images] callouts. To show/hide the title on a per-callout basis, please use the relevant metadata classes."
+                description.zh: "全局控制 [!images] 标注是否隐藏标题。如需为单个标注单独显示或隐藏标题，请使用相应元数据类。 选项含义：Hide Title (Default)：隐藏标题（默认）；Show Title：显示标题。"
+                description.zh-TW: "全域控制 [!images] 標註是否隱藏標題。如需為單個標註單獨顯示或隱藏標題，請使用相應後設資料類。 選項含義：Hide Title (Default)：隱藏標題（預設）；Show Title：顯示標題。"
                 allowEmpty: false
                 default: '0'
                 options:
@@ -48893,60 +50277,94 @@ settings:
     -
             id: callouts-gallery
             title: Gallery
+            title.zh: "画廊"
+            title.zh-TW: "畫廊"
             type: heading
             level: 4
             collapsed: false
     -
                 id: documentation-callouts-gallery
                 title: Documentation for Gallery-style Image Callouts
+                title.zh: "画廊式图片标注文档"
+                title.zh-TW: "畫廊式圖片標註文件"
                 type: info-text
                 description: "[Docs](https://willemstad.cc/Features/Callouts/Gallery)"
+                description.zh: "[文档](https://willemstad.cc/Features/Callouts/Gallery)"
+                description.zh-TW: "[文件](https://willemstad.cc/Features/Callouts/Gallery)"
                 markdown: true
     -
                 id: syntax-callouts-gallery
                 title: Syntax for Gallery-style Image Callouts
+                title.zh: "画廊式图片标注语法"
+                title.zh-TW: "畫廊式圖片標註語法"
                 type: class-toggle
                 description: ">[!images|gallery]"
+                description.zh: ">[!images|gallery]"
+                description.zh-TW: ">[!images|gallery]"
                 default: false
     -
                 id: radius-callouts-gallery
                 title: Image Border Radius in Gallery-style Image Callouts
+                title.zh: "画廊式图片标注的图片圆角半径"
+                title.zh-TW: "畫廊式圖片標註的圖片圓角半徑"
                 type: variable-text
                 description: "Controls the border radius of images inside gallery-style callouts. Accepts any valid CSS radius value (e.g., 0, 4px, var(--radius-m))."
+                description.zh: "控制画廊式标注内图片的圆角半径。接受有效的 CSS 圆角值，如 0、4px 或 var(--radius-m)。"
+                description.zh-TW: "控制畫廊式標註內圖片的圓角半徑。接受有效的 CSS 圓角值，如 0、4px 或 var(--radius-m)。"
                 default: 'var(--radius-image)'
     -
             id: callouts-image-grid
             title: Image Grid
+            title.zh: "图片网格"
+            title.zh-TW: "圖片網格"
             type: heading
             level: 4
             collapsed: false
     -
                 id: documentation-callouts-image-grid
                 title: Documentation for Grid-style Image Callouts
+                title.zh: "网格式图片标注文档"
+                title.zh-TW: "網格式圖片標註文件"
                 type: info-text
                 description: "[Docs](https://willemstad.cc/Features/Callouts/Image+Grid)"
+                description.zh: "[文档](https://willemstad.cc/Features/Callouts/Image+Grid)"
+                description.zh-TW: "[文件](https://willemstad.cc/Features/Callouts/Image+Grid)"
                 markdown: true
     -
                 id: syntax-callouts-image-grid
                 title: Syntax for Grid-style Image Callouts
+                title.zh: "网格式图片标注语法"
+                title.zh-TW: "網格式圖片標註語法"
                 type: class-toggle
                 description: ">[!images|grid]"
+                description.zh: ">[!images|grid]"
+                description.zh-TW: ">[!images|grid]"
                 default: false
     -
                 id: radius-callouts-img-grid
                 title: Image Border Radius in Grid-style Image Callouts
+                title.zh: "网格式图片标注的图片圆角半径"
+                title.zh-TW: "網格式圖片標註的圖片圓角半徑"
                 type: variable-text
                 description: "Controls the border radius of images inside gallery-style callouts. Accepts any valid CSS radius value (e.g., 0, 4px, var(--radius-m))."
+                description.zh: "控制画廊式标注内图片的圆角半径。接受有效的 CSS 圆角值，如 0、4px 或 var(--radius-m)。"
+                description.zh-TW: "控制畫廊式標註內圖片的圓角半徑。接受有效的 CSS 圓角值，如 0、4px 或 var(--radius-m)。"
                 default: 'var(--radius-image)'
     -
                 id: gap-callouts-img-grid
                 title: Gap between Images in Grid-style Image Callouts
+                title.zh: "网格式图片标注的图片间距"
+                title.zh-TW: "網格式圖片標註的圖片間距"
                 type: variable-text
                 description: "Controls the gap/spacing between images within an image grid callout. Accepts any valid CSS length (e.g., 4px, 0.5em, 1rem)."
+                description.zh: "控制图片网格标注中图片之间的间距。接受有效的 CSS 长度，如 4px、0.5em 或 1rem。"
+                description.zh-TW: "控制圖片網格標註中圖片之間的間距。接受有效的 CSS 長度，如 4px、0.5em 或 1rem。"
                 default: '4px'
     -
         id: cssclass-inline
         title: Inline CSSClass
+        title.zh: "局部 CSSClass"
+        title.zh-TW: "區域性 CSSClass"
         description: 
         type: heading
         level: 2
@@ -48954,42 +50372,66 @@ settings:
     -
             id: cssclass-banner
             title: Banner CSSClass
+            title.zh: "横幅 CSSClass"
+            title.zh-TW: "橫幅 CSSClass"
             type: heading
             level: 3
             collapsed: false
     -
                 id: documentation-cssclass-banner
                 title: Documentation for Banner CSSClass
+                title.zh: "横幅 CSSClass 文档"
+                title.zh-TW: "橫幅 CSSClass 文件"
                 type: info-text
                 description: "[Docs](https://willemstad.cc/Features/Inline+CSSClass/Banner+CSSClass)"
+                description.zh: "[文档](https://willemstad.cc/Features/Inline+CSSClass/Banner+CSSClass)"
+                description.zh-TW: "[文件](https://willemstad.cc/Features/Inline+CSSClass/Banner+CSSClass)"
                 markdown: true
     -
                 id: syntax-cssclass-banner
                 title: Syntax for Banner CSSClass
+                title.zh: "横幅 CSSClass 语法"
+                title.zh-TW: "橫幅 CSSClass 語法"
                 type: class-toggle
                 description: "cssclasses: [banner]"
+                description.zh: "cssclasses: [banner]"
+                description.zh-TW: "cssclasses: [banner]"
                 default: false
     -
             id: cssc-banner-height
             title: Banner Height
+            title.zh: "横幅高度"
+            title.zh-TW: "橫幅高度"
             type: variable-text
             description: "Sets the height of the banner image. You can use any valid CSS unit (e.g., 200px, 25vh)."
+            description.zh: "设置横幅图片高度。接受有效的 CSS 单位，如 200px 或 25vh。"
+            description.zh-TW: "設定橫幅圖片高度。接受有效的 CSS 單位，如 200px 或 25vh。"
             default: "200px"
     -
             id: cssc-banner-residual
             title: Banner Bottom Margin
+            title.zh: "横幅底部外边距"
+            title.zh-TW: "橫幅底部外邊距"
             type: variable-text
             description: "Sets the margin below the banner image, creating space between the banner and the content below it. Accepts any valid CSS unit (e.g., 0px, 1em)."
+            description.zh: "设置横幅图片底部外边距，控制横幅与下方内容的间距。接受有效的 CSS 单位，如 0px 或 1em。"
+            description.zh-TW: "設定橫幅圖片底部外邊距，控制橫幅與下方內容的間距。接受有效的 CSS 單位，如 0px 或 1em。"
             default: "0px"
     -
             id: cssc-banner-gradient-mask
             title: Banner Gradient Mask
+            title.zh: "横幅渐变遮罩"
+            title.zh-TW: "橫幅漸變遮罩"
             type: variable-text
             description: "Defines the linear gradient used to fade the bottom of the banner image. Modify this to change the fading effect."
+            description.zh: "定义使横幅图片底部逐渐淡出的线性渐变，修改此值可调整淡出效果。"
+            description.zh-TW: "定義使橫幅圖片底部逐漸淡出的線性漸變，修改此值可調整淡出效果。"
             default: "linear-gradient(to bottom, black 0%, black 50%, oklch(0 0 0 / 0.8) 75%, oklch(0 0 0 / 0.5) 80%, oklch(0 0 0 / 0.3) 85%, oklch(0 0 0 / 0.15) 90%, oklch(0 0 0 / 0.08) 95%, transparent 100%)"
     -
         id: html-features
         title: HTML Features
+        title.zh: "HTML 功能"
+        title.zh-TW: "HTML 功能"
         description: 
         type: heading
         level: 2
@@ -48997,44 +50439,68 @@ settings:
     -
             id: html-progress-bars
             title: Progress Bars
+            title.zh: "进度条"
+            title.zh-TW: "進度條"
             description: To use progress bars, use the following syntax below, which is also copyable for your own convenience. Change the value of the progress bar by changing the value attribute. Change the max value by changing the max attribute.
+            description.zh: "使用下方可复制的语法创建进度条。修改 value 属性可改变当前值，修改 max 属性可改变最大值。"
+            description.zh-TW: "使用下方可複製的語法建立進度條。修改 value 屬性可改變當前值，修改 max 屬性可改變最大值。"
             type: heading
             level: 3
             collapsed: false
     -
                 id: syntax-progress-bars
                 title: Syntax for Progress Bars
+                title.zh: "进度条语法"
+                title.zh-TW: "進度條語法"
                 type: class-toggle
                 document: EY21-HTML-ProgressBar
                 description: <progress value="50" max="100"></progress>
+                description.zh: "<progress value=\"50\" max=\"100\"></progress>"
+                description.zh-TW: "<progress value=\"50\" max=\"100\"></progress>"
                 default: false
     -
                 id: ssopt-progress-bar-original
                 title: Use Original Progress Bar Styling
+                title.zh: "使用原始进度条样式"
+                title.zh-TW: "使用原始進度條樣式"
                 type: class-toggle
                 document: EY21-HTML-ProgressBar
                 description: "Willemstad changes the default Progress Bar styling, however this is only appropriate for Progress Bars using a 0-100 scale. Toggling this would result in the original Progress Bar colour styling used instead."
+                description.zh: "Willemstad 自定义进度条样式仅适用于 0-100 的范围。启用此项可恢复原始进度条配色。"
+                description.zh-TW: "Willemstad 自訂進度條樣式僅適用於 0-100 的範圍。啟用此項可恢復原始進度條配色。"
                 default: false
     -
             id: html-aside
             title: HTML Aside
+            title.zh: "HTML 旁注"
+            title.zh-TW: "HTML 旁註"
             description: To use HTML Aside, use the following syntax below, which is also copyable for your own convenience. HTML Aside floats to the right by default, allowing you to add notes. Please note that markdown syntax DOES NOT work inside HTML Aside — instead, you must use HTML Syntax to reflect changes (for example, <b></b> instead of **** for bold text).
+            description.zh: "使用下方可复制的语法创建 HTML 旁注，默认向右浮动。HTML 旁注内部不支持 Markdown，必须使用 HTML 语法，例如用 <b></b> 而非 **** 表示粗体。"
+            description.zh-TW: "使用下方可複製的語法建立 HTML 旁註，預設向右浮動。HTML 旁註內部不支援 Markdown，必須使用 HTML 語法，例如用 <b></b> 而非 **** 表示粗體。"
             type: heading
             level: 3
             collapsed: false
     -
                 id: syntax-html-aside
                 title: Syntax for HTML Aside
+                title.zh: "HTML 旁注语法"
+                title.zh-TW: "HTML 旁註語法"
                 type: class-toggle
                 document: EY13-HTML-Aside
                 description: <aside>text goes here</aside>
+                description.zh: "<aside>text goes here</aside>"
+                description.zh-TW: "<aside>text goes here</aside>"
                 default: false
     -
                 id: aside-text-align
                 title: Text Alignment for HTML Aside
+                title.zh: "HTML 旁注文本对齐方式"
+                title.zh-TW: "HTML 旁註文本對齊方式"
                 type: variable-select
                 document: EY13-HTML-Aside
                 description: "This option allows one to change the text alignment and justification of the HTML Aside. By default, the text is aligned to the left."
+                description.zh: "设置 HTML 旁注的文本对齐方式，默认为左对齐。 选项含义：Left：左；Center：居中；Right：右；Justify：两端对齐。"
+                description.zh-TW: "設定 HTML 旁註的文本對齊方式，預設為左對齊。 選項含義：Left：左；Center：居中；Right：右；Justify：兩端對齊。"
                 default: left
                 options:
                     -
@@ -49052,9 +50518,13 @@ settings:
     -
                 id: aside-float
                 title: Float Alignment for HTML Aside
+                title.zh: "HTML 旁注浮动方向"
+                title.zh-TW: "HTML 旁註浮動方向"
                 type: variable-select
                 document: EY13-HTML-Aside
                 description: 'This option allows one to change the float alignment of the HTML Aside. By default, the aside is floated to the right. Should you choose to float it to the left, it is recommended to enable the "Overflow Fix" option.'
+                description.zh: "设置 HTML 旁注的浮动方向，默认为右侧。如改为左侧，建议同时启用“修复内容溢出”。 选项含义：Left：左；Right：右。"
+                description.zh-TW: "設定 HTML 旁註的浮動方向，預設為右側。如改為左側，建議同時啟用“修復內容溢位”。 選項含義：Left：左；Right：右。"
                 default: right
                 options:
                     -
@@ -49066,23 +50536,35 @@ settings:
     -
             id: html-infobox
             title: HTML Infobox
+            title.zh: "HTML 信息框"
+            title.zh-TW: "HTML 資訊框"
             description: To use HTML Infobox, use the following syntax below, which is also copyable for your own convenience. HTML Infobox is very similar to HTML Aside, except that the title in HTML Infobox is styled as well. Like in HTML Aside, markdown syntax DOES NOT work inside HTML Infobox — instead, you must use HTML Syntax to reflect changes (for example, <b></b> instead of **** for bold text).
+            description.zh: "使用下方可复制的语法创建 HTML 信息框。它类似 HTML 旁注，但也为标题提供样式。内部不支持 Markdown，必须使用 HTML 语法，例如用 <b></b> 而非 **** 表示粗体。"
+            description.zh-TW: "使用下方可複製的語法建立 HTML 資訊框。它類似 HTML 旁註，但也為標題提供樣式。內部不支援 Markdown，必須使用 HTML 語法，例如用 <b></b> 而非 **** 表示粗體。"
             type: heading
             level: 3
             collapsed: false
     -
                 id: syntax-html-infobox
                 title: Syntax for HTML Infobox
+                title.zh: "HTML 信息框语法"
+                title.zh-TW: "HTML 資訊框語法"
                 type: class-toggle
                 document: EY11-HTML-Infobox
                 description: <aside class=infobox><title>title goes here</title> text goes here</aside>
+                description.zh: "<aside class=infobox><title>title goes here</title> text goes here</aside>"
+                description.zh-TW: "<aside class=infobox><title>title goes here</title> text goes here</aside>"
                 default: false
     -
                 id: aside-infobox-float
                 title: Float Alignment for HTML Infobox
+                title.zh: "HTML 信息框浮动方向"
+                title.zh-TW: "HTML 資訊框浮動方向"
                 type: variable-select
                 document: EY11-HTML-Infobox
                 description: 'This option allows one to change the float alignment of the HTML Infobox. By default, the infobox is floated to the right. Should you choose to float it to the left, it is recommended to enable the "Overflow Fix" option.'
+                description.zh: "设置 HTML 信息框的浮动方向，默认为右侧。如改为左侧，建议同时启用“修复内容溢出”。 选项含义：Left：左；Right：右。"
+                description.zh-TW: "設定 HTML 資訊框的浮動方向，預設為右側。如改為左側，建議同時啟用“修復內容溢位”。 選項含義：Left：左；Right：右。"
                 default: right
                 options:
                     -
@@ -49100,6 +50582,8 @@ settings:
     -
         id: PComm001-settings
         title: Calendar
+        title.zh: "Calendar"
+        title.zh-TW: "Calendar"
         description:
         type: heading
         level: 2
@@ -49107,9 +50591,13 @@ settings:
     -
             id: color-text-today
             title: Colour for Today's Date
+            title.zh: "今日日期颜色"
+            title.zh-TW: "今日日期顏色"
             type: variable-select
             document: PC001-Calendar
             description: "This option allows one to choose one of the accent colours for today's date in the Calendar plugin."
+            description.zh: "为 Calendar 插件中的今日日期选择一种强调色。"
+            description.zh-TW: "為 Calendar 外掛中的今日日期選擇一種強調色。"
             default: var(--color-accent)
             options:
                 -
@@ -49124,9 +50612,13 @@ settings:
     -
             id: PComm001-col-year
             title: Colour for Year
+            title.zh: "年份颜色"
+            title.zh-TW: "年份顏色"
             type: variable-select
             document: PC001-Calendar
             description: "This option allows one to choose one of the accent colours for the year in the Calendar plugin."
+            description.zh: "为 Calendar 插件中的年份选择一种强调色。"
+            description.zh-TW: "為 Calendar 外掛中的年份選擇一種強調色。"
             default: var(--color-accent)
             options:
                 -
@@ -49141,6 +50633,8 @@ settings:
     -
         id: PComm002-settings
         title: Kanban
+        title.zh: "Kanban"
+        title.zh-TW: "Kanban"
         description: 
         type: heading
         level: 2
@@ -49148,26 +50642,38 @@ settings:
     -
             id: PComm002-sp-singlelane
             title: Vertical Scroll Kanbans in Side Panes
+            title.zh: "侧边面板看板纵向滚动"
+            title.zh-TW: "側邊面板看板縱向滾動"
             note: Kanban
             type: class-toggle
             document: PC002-Kanban
             description: When enabled, multiple kanban lanes in the side panes can be navigated via scrolling vertically rather than scrolling horizontally.
+            description.zh: "启用后，侧边面板中的多列看板采用纵向滚动，而非横向滚动。"
+            description.zh-TW: "啟用後，側邊面板中的多列看板採用縱向滾動，而非橫向滾動。"
             default: false
     -
             id: PComm002-sp-fitwidth
             title: Fit to Width of Side Panes
+            title.zh: "适应侧边面板宽度"
+            title.zh-TW: "適應側邊面板寬度"
             note: Kanban
             type: class-toggle
             document: PC002-Kanban
             description: When enabled, the kanban lanes in the side panes will fit to the width of the side panes.
+            description.zh: "启用后，看板列适应侧边面板宽度。"
+            description.zh-TW: "啟用後，看板列適應側邊面板寬度。"
             default: false
     -
             id: PComm002-sp-maxheight
             title: Max Height of Vertical Kanban Lane in Side Panes
+            title.zh: "侧边面板纵向看板列最大高度"
+            title.zh-TW: "側邊面板縱向看板列最大高度"
             note: Kanban
             type: variable-number-slider
             document: PC002-Kanban
             description: "Set the maximum height of each kanban lane in the side panes, when vertical."
+            description.zh: "设置侧边面板采用纵向布局时，每个看板列的最大高度。"
+            description.zh-TW: "設定側邊面板採用縱向佈局時，每個看板列的最大高度。"
             default: 33
             min: 5
             max: 100
@@ -49176,26 +50682,38 @@ settings:
     -
             id: PComm002-wp-singlelane
             title: 'Vertical Scroll Kanbans in Main Workspace (Editor) Panes'
+            title.zh: "主工作区（编辑器）面板看板纵向滚动"
+            title.zh-TW: "主工作區（編輯器）面板看板縱向滾動"
             note: Kanban
             type: class-toggle
             document: PC002-Kanban
             description: When enabled, multiple kanban lanes in the main workspace panes can be navigated via scrolling vertically rather than scrolling horizontally.
+            description.zh: "启用后，主工作区面板中的多列看板采用纵向滚动，而非横向滚动。"
+            description.zh-TW: "啟用後，主工作區面板中的多列看板採用縱向滾動，而非橫向滾動。"
             default: false
     -
             id: PComm002-wp-fitwidth
             title: 'Fit to Width of Main Workspace (Editor) Panes'
+            title.zh: "适应主工作区（编辑器）面板宽度"
+            title.zh-TW: "適應主工作區（編輯器）面板寬度"
             note: Kanban
             type: class-toggle
             document: PC002-Kanban
             description: When enabled, the kanban lanes in the main workspace panes will fit to the width of the pane.
+            description.zh: "启用后，看板列适应主工作区面板宽度。"
+            description.zh-TW: "啟用後，看板列適應主工作區面板寬度。"
             default: false
     -
             id: PComm002-wp-maxheight
             title: 'Max Height of Vertical Kanban Lane in Main Workspace (Editor) Panes'
+            title.zh: "主工作区（编辑器）面板纵向看板列最大高度"
+            title.zh-TW: "主工作區（編輯器）面板縱向看板列最大高度"
             note: Kanban
             type: variable-number-slider
             document: PC002-Kanban
             description: "Set the maximum height of each kanban lane in the main workspace panes, when vertical."
+            description.zh: "设置主工作区面板采用纵向布局时，每个看板列的最大高度。"
+            description.zh-TW: "設定主工作區面板採用縱向佈局時，每個看板列的最大高度。"
             default: 33
             min: 5
             max: 100
@@ -49204,19 +50722,27 @@ settings:
     -
             id: PComm002-canvas-background
             title: Enable Canvas-style Dotted Background for Kanban
+            title.zh: "为看板启用白板式圆点背景"
+            title.zh-TW: "為看板啟用白板式圓點背景"
             note: Kanban
             type: class-toggle
             document: PC002-Kanban
             description: When enabled, the kanban views will have a canvas-style dotted background.
+            description.zh: "启用后，看板视图使用白板式圆点背景。"
+            description.zh-TW: "啟用後，看板檢視使用白板式圓點背景。"
             default: false
     -
             id: PComm002-CB-bg-colour
             title: Background Colour (Canvas-style Background)
+            title.zh: "背景色（白板式背景）"
+            title.zh-TW: "背景色（白板式背景）"
             note: Kanban
             note2: (Requires 'Enable Canvas-style Dotted Background for Kanban' enabled)
             type: variable-select
             document: PC002-Kanban
             description: "This option allows one to choose one of the global accent and background colours for the canvas-style background."
+            description.zh: "从全局强调色和背景色中，为白板式背景选择颜色。"
+            description.zh-TW: "從全域強調色和背景色中，為白板式背景選擇顏色。"
             allowEmpty: false
             default: var(--background-primary)
             options:
@@ -49244,11 +50770,15 @@ settings:
     -
             id: PComm002-CB-dot-colour
             title: Dot Colour (Canvas-style Background)
+            title.zh: "圆点颜色（白板式背景）"
+            title.zh-TW: "圓點顏色（白板式背景）"
             note: Kanban
             note2: (Requires 'Enable Canvas-style Dotted Background for Kanban' enabled)
             type: variable-select
             document: PC002-Kanban
             description: "This option allows one to choose one of the global accent and background colours for the dots in the canvas-style background."
+            description.zh: "从全局强调色和背景色中，为白板式背景的圆点选择颜色。"
+            description.zh-TW: "從全域強調色和背景色中，為白板式背景的圓點選擇顏色。"
             allowEmpty: false
             default: var(--background-secondary-alt)
             options:
@@ -49276,11 +50806,15 @@ settings:
     -
             id: PComm002-CB-dot-size
             title: Dot Size (Canvas-style Background)
+            title.zh: "圆点大小（白板式背景）"
+            title.zh-TW: "圓點大小（白板式背景）"
             note: Kanban
             note2: (Requires 'Enable Canvas-style Dotted Background for Kanban' enabled)
             type: variable-number-slider
             document: PC002-Kanban
             description: "Set the size of the dots in the canvas-style background."
+            description.zh: "设置白板式背景的圆点大小。"
+            description.zh-TW: "設定白板式背景的圓點大小。"
             default: 1
             min: 0
             max: 5
@@ -49289,11 +50823,15 @@ settings:
     -
             id: PComm002-CB-dot-spacing
             title: Dot Spacing (Canvas-style Background)
+            title.zh: "圆点间距（白板式背景）"
+            title.zh-TW: "圓點間距（白板式背景）"
             note: Kanban
             note2: (Requires 'Enable Canvas-style Dotted Background for Kanban' enabled)
             type: variable-number-slider
             document: PC002-Kanban
             description: "Set the spacing of the dots in the canvas-style background."
+            description.zh: "设置白板式背景的圆点间距。"
+            description.zh-TW: "設定白板式背景的圓點間距。"
             default: 12
             min: 0
             max: 50
@@ -49302,6 +50840,8 @@ settings:
     -
         id: PComm005-settings
         title: Templater
+        title.zh: "Templater"
+        title.zh-TW: "Templater"
         description: 
         type: heading
         level: 2
@@ -49309,12 +50849,18 @@ settings:
     -
             id: PComm005-no-templater-tweaks
             title: Remove Willemstad-Set Templater Tweaks
+            title.zh: "移除 Willemstad 对 Templater 的样式调整"
+            title.zh-TW: "移除 Willemstad 對 Templater 的樣式調整"
             type: class-toggle
             document: PC005-Templater
             description: "Willemstad by default adds certain tweaks to the Templater plugin, including setting the same font-type and the disabling of text decoration for non-Templater items inline within a series of Templater code. When enabled, these tweaks will be removed."
+            description.zh: "Willemstad 默认对 Templater 做样式调整，包括统一字体，以及取消一段 Templater 代码中非 Templater 内联内容的文本装饰。启用此项可移除这些调整。"
+            description.zh-TW: "Willemstad 預設對 Templater 做樣式調整，包括統一字型，以及取消一段 Templater 程式碼中非 Templater 內聯內容的文本裝飾。啟用此項可移除這些調整。"
     -
         id: PComm007-settings
         title: Advanced Tables
+        title.zh: "Advanced Tables"
+        title.zh-TW: "Advanced Tables"
         description:
         type: heading
         level: 2
@@ -49322,16 +50868,24 @@ settings:
     -
             id: PComm007-no-adv-tables-toolbar-tweaks
             title: Remove Willemstad-Set Toolbar Tweaks
+            title.zh: "移除 Willemstad 对工具栏的样式调整"
+            title.zh-TW: "移除 Willemstad 對工具列的樣式調整"
             type: class-toggle
             document: PC007-AdvancedTables
             description: "By default, Willemstad tweaks the Advanced Tables toolbar to remove the prefixed explanations and the Advanced Tables toolbar title. This option allows you to remove these tweaks and restore the plugin's original toolbar appearance."
+            description.zh: "Willemstad 默认移除 Advanced Tables 工具栏的说明前缀与标题。启用此项可恢复插件原始工具栏外观。"
+            description.zh-TW: "Willemstad 預設移除 Advanced Tables 工具列的說明字首與標題。啟用此項可恢復外掛原始工具列外觀。"
             default: false
     -
             id: PComm007-toolbar-justification
             title: Toolbar Justification
+            title.zh: "工具栏对齐方式"
+            title.zh-TW: "工具列對齊方式"
             type: variable-select
             document: PC007-AdvancedTables
             description: "This option allows you to change the justification of the Advanced Tables Toolbar"
+            description.zh: "更改 Advanced Tables 工具栏的对齐方式。 选项含义：Left：左；Center：居中；Right：右。"
+            description.zh-TW: "更改 Advanced Tables 工具列的對齊方式。 選項含義：Left：左；Center：居中；Right：右。"
             default: left
             options:
                 -
@@ -49346,9 +50900,13 @@ settings:
     -
             id: PComm007-toolbar-title-justification
             title: Toolbar Title Justification
+            title.zh: "工具栏标题对齐方式"
+            title.zh-TW: "工具列標題對齊方式"
             type: variable-select
             document: PC007-AdvancedTables
             description: "This option allows you to change the justification of the Advanced Tables Toolbar"
+            description.zh: "更改 Advanced Tables 工具栏的对齐方式。 选项含义：Left：左；Center：居中；Right：右。"
+            description.zh-TW: "更改 Advanced Tables 工具列的對齊方式。 選項含義：Left：左；Center：居中；Right：右。"
             default: 0 auto 0 0
             options:
                 -
@@ -49363,6 +50921,8 @@ settings:
     -
         id: PComm009-settings
         title: Full Calendar
+        title.zh: "Full Calendar"
+        title.zh-TW: "Full Calendar"
         description: 
         type: heading
         level: 2
@@ -49370,12 +50930,18 @@ settings:
     -
             id: PComm009-no-halfhour-grid
             title: Remove Half-Hour Demarcation Lines
+            title.zh: "移除半小时分隔线"
+            title.zh-TW: "移除半小時分隔線"
             type: class-toggle
             document: PC009-FullCalendar
             description: "The Full Calendar plugin has half-hour lines by default. When this option is enabled, the half-hour demarcation lines will be removed."
+            description.zh: "Full Calendar 默认显示半小时分隔线。启用此项后移除这些线。"
+            description.zh-TW: "Full Calendar 預設顯示半小時分隔線。啟用此項後移除這些線。"
     -
         id: PComm010-settings
         title: Excalidraw
+        title.zh: "Excalidraw"
+        title.zh-TW: "Excalidraw"
         description: 
         type: heading
         level: 2
@@ -49383,13 +50949,19 @@ settings:
     -
             id: PComm010-original-colours
             title: Use Original Excalidraw Colour Styling
+            title.zh: "使用 Excalidraw 原始配色"
+            title.zh-TW: "使用 Excalidraw 原始配色"
             type: class-toggle
             document: PC010-Excalidraw
             description: "Willemstad changes the default Excalidraw colour styling to match the theme. When enabled, the original Excalidraw colour styling will be used."
+            description.zh: "Willemstad 默认调整 Excalidraw 配色以匹配主题。启用此项可恢复 Excalidraw 原始配色。"
+            description.zh-TW: "Willemstad 預設調整 Excalidraw 配色以匹配主題。啟用此項可恢復 Excalidraw 原始配色。"
             default: false
     -
         id: PComm011-settings
         title: Hover Editor
+        title.zh: "Hover Editor"
+        title.zh-TW: "Hover Editor"
         description: 
         type: heading
         level: 2
@@ -49397,10 +50969,14 @@ settings:
     -
             id: PComm011-no-sync-colours
             title: Use Non-Coloured Titlebar Styling
+            title.zh: "使用无强调色标题栏样式"
+            title.zh-TW: "使用無強調色標題列樣式"
             type: class-toggle
             document: PComm011-HoverEditor
             note: (Requires 'Use Accent Colour for Titlebar' enabled)
             description: "Willemstad changes the titlebar colour to match the theme. This means that the titlebar colour for Hover Editor also changes, whilst 'Use Accent Colour for Titlebar' is enabled. When this option is enabled, the original tab bar colour will be used instead."
+            description.zh: "启用“标题栏使用强调色”时，Hover Editor 的标题栏也随主题配色改变。启用此项后改用原始标签栏颜色。"
+            description.zh-TW: "啟用“標題列使用強調色”時，Hover Editor 的標題列也隨主題配色改變。啟用此項後改用原始標籤欄顏色。"
             default: false
 
 */
@@ -49412,79 +50988,131 @@ settings:
     -
         id: info-credits-willemstad
         title: 'Supporting Willemstad'
+        title.zh: "支持 Willemstad"
+        title.zh-TW: "支援 Willemstad"
         type: info-text
         description: 'As a matter of principle, I have not, do not, and will not accept monetary compensation/donations of any kind for Willemstad, as my intention has always been to create something that works for me and contribute back to the community. In the event you would like to support Willemstad, please spread the word about the theme, and star the GitHub repository, accessible on the button to the right. Should you still wish to contribute monetarily, please direct your funds elsewhere to other Obsidian community members and theme developers in this list, all of which have contributed to Willemstad and/or the Obsidian theme development scene in one way or another. [GitHub Repository](https://github.com/tingmelvin/willemstad-x)'
+        description.zh: "Willemstad 的作者始终不接受任何形式的报酬或捐赠，创作目的在于满足自身需要并回馈社区。如想支持 Willemstad，请向他人介绍主题，或为 GitHub 仓库加星。如希望提供资金支持，请支持本列表中的其他 Obsidian 社区成员和主题开发者，他们都为 Willemstad 或 Obsidian 主题生态作出过贡献。 [GitHub 代码仓库](https://github.com/tingmelvin/willemstad-x)"
+        description.zh-TW: "Willemstad 的作者始終不接受任何形式的報酬或捐贈，創作目的在於滿足自身需要並回饋社群。如想支援 Willemstad，請向他人介紹主題，或為 GitHub 倉庫加星。如希望提供資金支援，請支援本列表中的其他 Obsidian 社群成員和主題開發者，他們都為 Willemstad 或 Obsidian 主題生態作出過貢獻。 [GitHub 程式碼倉庫](https://github.com/tingmelvin/willemstad-x)"
         markdown: true
     -
         id: info-credits-pseudometa
         title: 'Chris Grieser (@pseudometa)'
+        title.zh: "Chris Grieser (@pseudometa)"
+        title.zh-TW: "Chris Grieser (@pseudometa)"
         type: info-text
         description: "Theme developer of Shimmering Focus and various plugins for Obsidian and Alfred, and Obsidian's resident minimalist; Willemstad's original form as a snippet was built upon SF, and pretty much Willemstad's existence (and quite a number of its early code and its support for Longform) can be attributed to Chris [Ko-Fi](https://ko-fi.com/pseudometa) [GitHub](https://github.com/chrisgrieser/)"
+        description.zh: "Shimmering Focus 主题及多个 Obsidian、Alfred 插件的开发者，也是 Obsidian 社区的极简风格倡导者。Willemstad 最初是基于 Shimmering Focus 的代码片段，其诞生、许多早期代码以及 Longform 支持都得益于 Chris。 [Ko-Fi](https://ko-fi.com/pseudometa) [GitHub](https://github.com/chrisgrieser/)"
+        description.zh-TW: "Shimmering Focus 主題及多個 Obsidian、Alfred 外掛的開發者，也是 Obsidian 社群的極簡風格倡導者。Willemstad 最初是基於 Shimmering Focus 的程式碼片段，其誕生、許多早期程式碼以及 Longform 支援都得益於 Chris。 [Ko-Fi](https://ko-fi.com/pseudometa) [GitHub](https://github.com/chrisgrieser/)"
         markdown: true
     -
         id: info-credits-damikiller
         title: 'Damian Korcz'
+        title.zh: "Damian Korcz"
+        title.zh-TW: "Damian Korcz"
         type: info-text
         description: "Theme developer of Prism, and Maintainer of the Alternative Checkboxes Reference Set; for contributing input to the No-Shadow Sliding Panes and literally saving weeks of my time by introducing and teaching me how to compile SASS/SCSS (if not, Willemstad would be totally unmaintainable since it consists of almost 130 SCSS files and way too many mixins); almost every wacky idea in early Willemstad has roots to him [BuyMeACoffee](https://www.buymeacoffee.com/DamianKorcz) [GitHub](https://github.com/damiankorcz)"
+        description.zh: "Prism 主题开发者与扩展复选框参考规范维护者。他参与无阴影滑动面板的设计，并教会作者编译 SASS/SCSS，节省了大量时间，使包含近 130 个 SCSS 文件和众多 mixin 的 Willemstad 得以维护。早期主题的许多创意都源自他的帮助。 [BuyMeACoffee](https://www.buymeacoffee.com/DamianKorcz) [GitHub](https://github.com/damiankorcz)"
+        description.zh-TW: "Prism 主題開發者與擴充套件核取方塊參考規範維護者。他參與無陰影滑動面板的設計，並教會作者編譯 SASS/SCSS，節省了大量時間，使包含近 130 個 SCSS 檔案和眾多 mixin 的 Willemstad 得以維護。早期主題的許多創意都源自他的幫助。 [BuyMeACoffee](https://www.buymeacoffee.com/DamianKorcz) [GitHub](https://github.com/damiankorcz)"
         markdown: true
     -
         id: info-credits-ceciliamay
         title: 'Cecilia May'
+        title.zh: "Cecilia May"
+        title.zh-TW: "Cecilia May"
         type: info-text
         description: "Theme developer of Primary and pretty much Obsidian's purveyor of colours; whom I co-wrote the Varying/Readable Underlines code with [Ko-Fi](https://ko-fi.com/ceciliamay) [GitHub](https://github.com/ceciliamay)"
+        description.zh: "Primary 主题开发者，擅长为 Obsidian 设计配色；与作者共同编写了可调整间距、提高可读性的下划线代码。 [Ko-Fi](https://ko-fi.com/ceciliamay) [GitHub](https://github.com/ceciliamay)"
+        description.zh-TW: "Primary 主題開發者，擅長為 Obsidian 設計配色；與作者共同編寫了可調整間距、提高可讀性的底線程式碼。 [Ko-Fi](https://ko-fi.com/ceciliamay) [GitHub](https://github.com/ceciliamay)"
         markdown: true
     -
         id: info-credits-slrvb
         title: 'SlRvB'
+        title.zh: "SlRvB"
+        title.zh-TW: "SlRvB"
         type: info-text
         description: "Theme developer of ITS Theme; the brains behind a lot of the wonderful things now seen in Obsidian themes; for the Dataview Word Wraps solutions [Ko-Fi](https://ko-fi.com/slrvb) [GitHub](https://github.com/SlRvB)"
+        description.zh: "ITS Theme 开发者，构思了许多现已应用于 Obsidian 主题的功能，并提供 Dataview 自动换行方案。 [Ko-Fi](https://ko-fi.com/slrvb) [GitHub](https://github.com/SlRvB)"
+        description.zh-TW: "ITS Theme 開發者，構思了許多現已應用於 Obsidian 主題的功能，並提供 Dataview 自動換行方案。 [Ko-Fi](https://ko-fi.com/slrvb) [GitHub](https://github.com/SlRvB)"
         markdown: true
     -
         id: info-credits-kepano
         title: 'Stephan Ango (@kepano)'
+        title.zh: "Stephan Ango (@kepano)"
+        title.zh-TW: "Stephan Ango (@kepano)"
         type: info-text
         description: "Theme developer of Minimal (and Flexoki) and Obsidian's CEO; for writing Minimal Cards and Grids previously included in Willemstad, and for the Flexoki colour scheme now supported by Willemstad in its base tones and syntax highlighting [BuyMeACoffee](https://www.buymeacoffee.com/kepano) [GitHub](https://github.com/kepano)"
+        description.zh: "Minimal 和 Flexoki 主题开发者、Obsidian CEO。创作了 Willemstad 曾集成的 Minimal 卡片与网格，并提供如今用于基础色调与语法高亮的 Flexoki 配色。 [BuyMeACoffee](https://www.buymeacoffee.com/kepano) [GitHub](https://github.com/kepano)"
+        description.zh-TW: "Minimal 和 Flexoki 主題開發者、Obsidian CEO。創作了 Willemstad 曾整合的 Minimal 卡片與網格，並提供如今用於基礎色調與語法高亮的 Flexoki 配色。 [BuyMeACoffee](https://www.buymeacoffee.com/kepano) [GitHub](https://github.com/kepano)"
         markdown: true
     -
         id: info-credits-jdanielmourao
         title: '@jdanielmourao'
+        title.zh: "@jdanielmourao"
+        title.zh-TW: "@jdanielmourao"
         type: info-text
         description: "Theme developer of Sanctum; for having written the original theme I used in Obsidian whilst studying at the London School of Hygiene and Tropical Medicine and for hearing my constant lamentations about how he changed something up in Sanctum's early days that was breaking my workflow [Ko-fi](https://ko-fi.com/jdanielmourao) [GitHub](https://github.com/jdanielmourao)"
+        description.zh: "Sanctum 主题开发者。作者在伦敦卫生与热带医学院学习时使用了该主题，也感谢他耐心倾听早期主题改动对作者工作流程造成影响的反馈。 [Ko-fi](https://ko-fi.com/jdanielmourao) [GitHub](https://github.com/jdanielmourao)"
+        description.zh-TW: "Sanctum 主題開發者。作者在倫敦衛生與熱帶醫學院學習時使用了該主題，也感謝他耐心傾聽早期主題改動對作者工作流程造成影響的反饋。 [Ko-fi](https://ko-fi.com/jdanielmourao) [GitHub](https://github.com/jdanielmourao)"
         markdown: true
     -
         id: info-credits-zcysxy
         title: 'Zhang Chenyu (@zcysxy/Atlas)'
+        title.zh: "Zhang Chenyu (@zcysxy/Atlas)"
+        title.zh-TW: "Zhang Chenyu (@zcysxy/Atlas)"
         type: info-text
         description: "Theme developer of Terminal; For writing the Multi-Colour Highlighting code that was adapted by Willemstad in its very early days [Ko-Fi](https://ko-fi.com/zcysxy) [GitHub](https://github.com/zcysxy)"
+        description.zh: "Terminal 主题开发者。他编写的多色高亮代码在 Willemstad 早期被改编采用。 [Ko-Fi](https://ko-fi.com/zcysxy) [GitHub](https://github.com/zcysxy)"
+        description.zh-TW: "Terminal 主題開發者。他編寫的多色高亮程式碼在 Willemstad 早期被改編採用。 [Ko-Fi](https://ko-fi.com/zcysxy) [GitHub](https://github.com/zcysxy)"
         markdown: true
     -
         id: info-credits-mgmeyers
         title: 'Matthew Meyers (@mgmeyers)'
+        title.zh: "Matthew Meyers (@mgmeyers)"
+        title.zh-TW: "Matthew Meyers (@mgmeyers)"
         type: info-text
         description: "Now one of Obsidian's developers, also theme developer of California Coast, and developer of various plugins in Obsidian, including Kanban and the very cherished Style Settings plugin [BuyMeACoffee](https://www.buymeacoffee.com/mgme) [GitHub](https://github.com/chetachiezikeuzor)"
+        description.zh: "Obsidian 开发团队成员、California Coast 主题开发者，以及 Kanban、Style Settings 等多个 Obsidian 插件的开发者。 [BuyMeACoffee](https://www.buymeacoffee.com/mgme) [GitHub](https://github.com/chetachiezikeuzor)"
+        description.zh-TW: "Obsidian 開發團隊成員、California Coast 主題開發者，以及 Kanban、Style Settings 等多個 Obsidian 外掛的開發者。 [BuyMeACoffee](https://www.buymeacoffee.com/mgme) [GitHub](https://github.com/chetachiezikeuzor)"
         markdown: true
     -
         id: info-credits-chetachi
         title: 'Chetachi Ezikeuzor (@chetachi)'
+        title.zh: "Chetachi Ezikeuzor (@chetachi)"
+        title.zh-TW: "Chetachi Ezikeuzor (@chetachi)"
         type: info-text
         description: "Theme developer of Yin and Yang; for popularising Base64 font encoding amongst theme developers in Obsidian [Ko-Fi](https://ko-fi.com/chetachi) [GitHub](https://github.com/chetachiezikeuzor)"
+        description.zh: "Yin and Yang 主题开发者，推动了 Base64 字体编码在 Obsidian 主题开发中的使用。 [Ko-Fi](https://ko-fi.com/chetachi) [GitHub](https://github.com/chetachiezikeuzor)"
+        description.zh-TW: "Yin and Yang 主題開發者，推動了 Base64 字型編碼在 Obsidian 主題開發中的使用。 [Ko-Fi](https://ko-fi.com/chetachi) [GitHub](https://github.com/chetachiezikeuzor)"
         markdown: true
     -
         id: info-credits-others
         title: 'Special Thanks'
+        title.zh: "特别鸣谢"
+        title.zh-TW: "特別鳴謝"
         type: info-text
         description: "Willemstad also gives its special thanks to Rasmus Andersson (Inter font), Mikhail Sharanda (Manrope font), Colophon Foundry (DM Sans and DM Mono fonts), Jacques Le Bailly/Sebastian Kosch (Crimson Pro font), Nate Baldwin et al. (Leonardo), Blake Robert Mills (MetBrewer), Jimmy Cheung et al. (RemixIcons), Tobias Fried (Phosphor Icons), Cole Bemis et al. (Lucide Icons). Where available, their GitHub repositories are linked here. [](https://github.com/rsms/inter) [](https://github.com/adobe/leonardo) [](https://github.com/BlakeRMills/MetBrewer) [](https://github.com/Remix-Design/RemixIcon) [](https://github.com/phosphor-icons/homepage) [](https://github.com/lucide-icons/lucide)"
+        description.zh: "特别感谢 Rasmus Andersson（Inter 字体）、Mikhail Sharanda（Manrope 字体）、Colophon Foundry（DM Sans 和 DM Mono 字体）、Jacques Le Bailly 与 Sebastian Kosch（Crimson Pro 字体）、Nate Baldwin 等（Leonardo）、Blake Robert Mills（MetBrewer）、Jimmy Cheung 等（RemixIcons）、Tobias Fried（Phosphor Icons）、Cole Bemis 等（Lucide Icons）。下方提供了可用的 GitHub 仓库链接。 [](https://github.com/rsms/inter) [](https://github.com/adobe/leonardo) [](https://github.com/BlakeRMills/MetBrewer) [](https://github.com/Remix-Design/RemixIcon) [](https://github.com/phosphor-icons/homepage) [](https://github.com/lucide-icons/lucide)"
+        description.zh-TW: "特別感謝 Rasmus Andersson（Inter 字型）、Mikhail Sharanda（Manrope 字型）、Colophon Foundry（DM Sans 和 DM Mono 字型）、Jacques Le Bailly 與 Sebastian Kosch（Crimson Pro 字型）、Nate Baldwin 等（Leonardo）、Blake Robert Mills（MetBrewer）、Jimmy Cheung 等（RemixIcons）、Tobias Fried（Phosphor Icons）、Cole Bemis 等（Lucide Icons）。下方提供了可用的 GitHub 倉庫連結。 [](https://github.com/rsms/inter) [](https://github.com/adobe/leonardo) [](https://github.com/BlakeRMills/MetBrewer) [](https://github.com/Remix-Design/RemixIcon) [](https://github.com/phosphor-icons/homepage) [](https://github.com/lucide-icons/lucide)"
         markdown: true
     -
         id: info-credits-theme-showcase
         title: 'Theme Showcase'
+        title.zh: "主题展示"
+        title.zh-TW: "主題展示"
         type: info-text
         description: "This segment is reserved for showcasing themes beyond Willemstad, which have pushed the boundaries of what is possible with CSS in Obsidian. Stay tuned for more!"
+        description.zh: "此区域将展示 Willemstad 之外、拓展 Obsidian CSS 可能性的主题，敬请关注。"
+        description.zh-TW: "此區域將展示 Willemstad 之外、拓展 Obsidian CSS 可能性的主題，敬請關注。"
     -
         id: info-credits-obsidian
         title: 'Supporting Obsidian'
+        title.zh: "支持 Obsidian"
+        title.zh-TW: "支援 Obsidian"
         type: info-text
         description: "Last but not least, you can also choose to support Obsidian by purchasing a Catalyst license, or by subscribing to Obsidian Publish and/or Obsidian Sync. [Catalyst](https://obsidian.md/account/catalyst) [Sync](https://obsidian.md/sync) [Publish](https://obsidian.md/publish)"
+        description.zh: "也可通过购买 Catalyst 许可，或订阅 Obsidian Publish、Obsidian Sync 来支持 Obsidian。 [Catalyst](https://obsidian.md/account/catalyst) [Sync](https://obsidian.md/sync) [Publish](https://obsidian.md/publish)"
+        description.zh-TW: "也可通過購買 Catalyst 許可，或訂閱 Obsidian Publish、Obsidian Sync 來支援 Obsidian。 [Catalyst](https://obsidian.md/account/catalyst) [Sync](https://obsidian.md/sync) [Publish](https://obsidian.md/publish)"
         markdown: true
 */
 
@@ -49495,35 +51123,55 @@ settings:
     -
         id: immersive-editing-modes
         title: Immersive Editing Modes (Focused Mode and Super Focused Mode)
+        title.zh: "沉浸式编辑模式（专注与超级专注模式）"
+        title.zh-TW: "沉浸式編輯模式（專注與超級專注模式）"
         type: heading
         description: "Styles that hide UI elements and fade out non-active lines to help you focus on writing."
+        description.zh: "隐藏界面元素，并淡化非当前行的文本，帮助专注写作。"
+        description.zh-TW: "隱藏介面元素，並淡化非當前行的文本，幫助專注寫作。"
         level: 3
         collapsed: false
     -
         id: info-immersive-editing-modes
         title: Note on Immersive Editing Modes
+        title.zh: "沉浸式编辑模式说明"
+        title.zh-TW: "沉浸式編輯模式說明"
         type: info-text
         description: "Please note that the immersive editing modes (Focused and Super Focused Modes) can be set via hotkeys and is accessible via the Command Palette. Please see the Obsidian's documentation (accessible via the button on the right) to do this. Immersive Editing Modes takes inspiration from [Ryan McQuen's Focus Mode plugin](https://github.com/ryanpcmcquen/obsidian-focus-mode), which Willemstad's maintainer used to use extensively years ago. [Obsidian Docs](https://help.obsidian.md/hotkeys)"
+        description.zh: "专注与超级专注模式可通过快捷键或命令面板切换，具体设置方法请见右侧 Obsidian 文档。沉浸式编辑模式受到 Ryan McQuen 的 Focus Mode 插件启发，Willemstad 维护者曾长期使用该插件。 [Ryan McQuen's Focus Mode plugin](https://github.com/ryanpcmcquen/obsidian-focus-mode) [Obsidian 文档](https://help.obsidian.md/hotkeys)"
+        description.zh-TW: "專注與超級專注模式可通過快捷鍵或命令面板切換，具體設定方法請見右側 Obsidian 文件。沉浸式編輯模式受到 Ryan McQuen 的 Focus Mode 外掛啟發，Willemstad 維護者曾長期使用該外掛。 [Ryan McQuen's Focus Mode plugin](https://github.com/ryanpcmcquen/obsidian-focus-mode) [Obsidian 文件](https://help.obsidian.md/hotkeys)"
         markdown: true
     -
         id: ssopt-focused-mode
         title: Focused Mode
+        title.zh: "专注模式"
+        title.zh-TW: "專注模式"
         type: class-toggle
         description: "Hides all UI elements (status bar, sidebars, etc.) except for the tab header bar, and fades out lines of text that are not near your active line. Please note that this setting can be set to a hotkey, and is available via your Command Palette."
+        description.zh: "隐藏标签页顶部栏之外的界面元素（状态栏、侧边栏等），并淡化远离当前行的文本。可为此设置快捷键，也可从命令面板切换。"
+        description.zh-TW: "隱藏標籤頁頂部欄之外的介面元素（狀態列、側邊欄等），並淡化遠離當前行的文本。可為此設定快捷鍵，也可從命令面板切換。"
         default: false
         addCommand: true
     -
         id: ssopt-super-focused-mode
         title: Super Focused Mode
+        title.zh: "超级专注模式"
+        title.zh-TW: "超級專注模式"
         type: class-toggle
         description: "An even more extreme focus mode. Hides all elements, except the current active page. Does not require 'Focused Mode' enabled. Please note that this setting can be set to a hotkey, and is available via your Command Palette."
+        description.zh: "更彻底的专注模式，只保留当前页面，隐藏其他元素。无需先启用“专注模式”。可设置快捷键，也可从命令面板切换。"
+        description.zh-TW: "更徹底的專注模式，只保留當前頁面，隱藏其他元素。無需先啟用“專注模式”。可設定快捷鍵，也可從命令面板切換。"
         default: false
         addCommand: true
     -
         id: distant-opacity
         title: Distant Line Opacity
+        title.zh: "远离当前行的文本不透明度"
+        title.zh-TW: "遠離當前行的文本不透明度"
         type: variable-number-slider
         description: "Controls the minimum opacity for lines far away from your active line in Focused Mode. Default is 0.2."
+        description.zh: "控制专注模式下远离当前行的文本所采用的最低不透明度。默认为 0.2。"
+        description.zh-TW: "控制專注模式下遠離當前行的文本所採用的最低不透明度。預設為 0.2。"
         format: ""
         min: 0
         max: 1
@@ -49532,8 +51180,12 @@ settings:
     -
         id: near-fade-factor
         title: Near Line Fade Factor
+        title.zh: "邻近行淡出系数"
+        title.zh-TW: "鄰近行淡出係數"
         type: variable-number-slider
         description: "Controls the opacity of the lines fade out as they get further from the active line. Higher values mean a bigger difference in opacity, which is stepped by the value you input here, multiplied by the amount of lines away from the active line it is (up to the third line). The default is 0.15."
+        description.zh: "控制文本行远离当前行时的淡出幅度。数值越大，不透明度差异越明显；每多隔一行按此值递增计算，最多计算到第三行。默认为 0.15。"
+        description.zh-TW: "控制文本行遠離當前行時的淡出幅度。數值越大，不透明度差異越明顯；每多隔一行按此值遞增計算，最多計算到第三行。預設為 0.15。"
         format: ""
         min: 0
         max: 0.5
@@ -49818,21 +51470,33 @@ settings:
     -
         id: cssc-latex
         title: " Display CSSClass"
+        title.zh: "LaTeX 排版 CSSClass"
+        title.zh-TW: "LaTeX 排版 CSSClass"
         description: "Transform your notes into beautiful LaTeX-style documents. Creates academic paper styling with proper typography, equation numbering, and LaTeX-like formatting for professional document presentation. To use LaTeX Display CSSClass, type `cssclasses: latex` in the document's YAML."
+        description.zh: "将笔记呈现为 LaTeX 风格学术文档，包括排版、公式编号和类似 LaTeX 的格式。在笔记 YAML 中加入 `cssclasses: latex` 即可使用。"
+        description.zh-TW: "將筆記呈現為 LaTeX 風格學術文件，包括排版、公式編號和類似 LaTeX 的格式。在筆記 YAML 中加入 `cssclasses: latex` 即可使用。"
         type: heading
         level: 3
         collapsed: false
     -
         id: documentation-cssclass-latex
         title: Documentation for LaTeX Display CSSClass
+        title.zh: "LaTeX 排版 CSSClass 文档"
+        title.zh-TW: "LaTeX 排版 CSSClass 文件"
         type: info-text
         description: "[Example](https://willemstad.cc/Features/Global+CSSClass/LaTeX+Display+Example) [Docs](https://willemstad.cc/Features/Global+CSSClass/LaTeX+Display)"
+        description.zh: "[示例](https://willemstad.cc/Features/Global+CSSClass/LaTeX+Display+Example) [文档](https://willemstad.cc/Features/Global+CSSClass/LaTeX+Display)"
+        description.zh-TW: "[示例](https://willemstad.cc/Features/Global+CSSClass/LaTeX+Display+Example) [文件](https://willemstad.cc/Features/Global+CSSClass/LaTeX+Display)"
         markdown: true
     -
         id: cssc-latex-font-size
         title: "Font Size"
+        title.zh: "字号"
+        title.zh-TW: "字級"
         type: variable-number-slider
         description: "Sets the base font size for the LaTeX document style."
+        description.zh: "设置 LaTeX 文档样式的基础字号。"
+        description.zh-TW: "設定 LaTeX 文件樣式的基礎字級。"
         default: 14
         min: 10
         max: 20
@@ -49841,20 +51505,32 @@ settings:
     -
         id: cssc-latex-font-reading
         title: "Reading Font Family"
+        title.zh: "阅读模式字体"
+        title.zh-TW: "閱讀模式字型"
         type: variable-text
         description: "Font family used for reading mode. Supports multiple fallbacks."
+        description.zh: "阅读模式使用的字体，可填写多个后备字体。"
+        description.zh-TW: "閱讀模式使用的字型，可填寫多個備用字型。"
         default: '"MathJax Main", "MJXZERO", "MJXTEX"'
     -
         id: cssc-latex-font-source
         title: "Source/Editor Font Family"
+        title.zh: "源码与编辑模式字体"
+        title.zh-TW: "原始碼與編輯模式字型"
         type: variable-text
         description: "Font family used in source/editor mode. Supports multiple fallbacks."
+        description.zh: "源码或编辑模式使用的字体，可填写多个后备字体。"
+        description.zh-TW: "原始碼或編輯模式使用的字型，可填寫多個備用字型。"
         default: '"DM Mono", "MathJax Main", "MJXZERO", "MJXTEX"'
     -
         id: cssc-latex-text-indent
         title: "Paragraph Text Indent"
+        title.zh: "段落首行缩进"
+        title.zh-TW: "段落首行縮排"
         type: variable-number-slider
         description: "Sets the indentation for the first line of paragraphs."
+        description.zh: "设置段落首行缩进。"
+        description.zh-TW: "設定段落首行縮排。"
         default: 0
         min: 0
         max: 3
@@ -49863,8 +51539,12 @@ settings:
     -
         id: cssc-latex-table-preview-font-size
         title: "Table Font Size (Preview)"
+        title.zh: "表格字号（预览）"
+        title.zh-TW: "表格字級（預覽）"
         type: variable-number-slider
         description: "Font size for tables in reading/preview mode."
+        description.zh: "阅读或预览模式中的表格字号。"
+        description.zh-TW: "閱讀或預覽模式中的表格字級。"
         default: 1
         min: 0.7
         max: 1.5
@@ -49873,8 +51553,12 @@ settings:
     -
         id: cssc-latex-table-editor-font-size
         title: "Table Font Size (Editor)"
+        title.zh: "表格字号（编辑）"
+        title.zh-TW: "表格字級（編輯）"
         type: variable-number-slider
         description: "Font size for tables in editor/live preview mode."
+        description.zh: "编辑或实时预览模式中的表格字号。"
+        description.zh-TW: "編輯或即時預覽模式中的表格字級。"
         default: 0.8
         min: 0.6
         max: 1.2
@@ -49883,10 +51567,14 @@ settings:
     -
         id: cssc-latex-equation-counter-format
         title: "Equation Number Format"
+        title.zh: "公式编号格式"
+        title.zh-TW: "公式編號格式"
         type: class-select
         allowEmpty: false
         default: default
         description: "Format for equation numbering."
+        description.zh: "设置公式编号格式。 选项含义：Parentheses: (1)：圆括号：(1)；Brackets: [1]：方括号：[1]；Plain: 1：仅数字：1。"
+        description.zh-TW: "設定公式編號格式。 選項含義：Parentheses: (1)：圓括號：(1)；Brackets: [1]：方括號：[1]；Plain: 1：僅數字：1。"
         options:
             -
                 label: 'Parentheses: (1)'
@@ -49900,8 +51588,12 @@ settings:
     -
         id: ssopt-cssc-latex-preserve-bg-colour
         title: "Preserve Theme Background Colour in LaTeX CSSClass PDF Exports"
+        title.zh: "LaTeX CSSClass 导出 PDF 时保留主题背景色"
+        title.zh-TW: "LaTeX CSSClass 匯出 PDF 時保留主題背景色"
         type: class-toggle
         description: "By default, LaTeX documents generally should be exported to white backgrounds, and thus this CSSClass overrides the print stylesheet available for the rest of Willemstad. Toggle this to force the LaTeX CSSClass document to take the background colour of the theme when exporting."
+        description.zh: "LaTeX 文档通常使用白色背景导出，因此此 CSSClass 默认覆盖 Willemstad 的其他打印样式。启用此项可在导出时保留主题背景色。"
+        description.zh-TW: "LaTeX 文件通常使用白色背景匯出，因此此 CSSClass 預設覆蓋 Willemstad 的其他列印樣式。啟用此項可在匯出時保留主題背景色。"
         default: false
 */
 
@@ -50089,21 +51781,33 @@ settings:
     -
         id: cssc-cornell
         title: "Cornell Notes CSSClass"
+        title.zh: "康奈尔笔记 CSSClass"
+        title.zh-TW: "康奈爾筆記 CSSClass"
         description: "Transform your notes into the classic Cornell Note-taking format with a two-column layout: a narrow left column for keywords and cues, and a wider right column for detailed content. To use Cornell Notes CSSClass, type `cssclasses: cornell` in the document's YAML."
+        description.zh: "将笔记转换为经典的康奈尔双栏笔记：左侧窄栏放关键词和提示，右侧宽栏放详细内容。在笔记 YAML 中加入 `cssclasses: cornell` 即可使用。"
+        description.zh-TW: "將筆記轉換為經典的康奈爾雙欄筆記：左側窄欄放關鍵詞和提示，右側寬欄放詳細內容。在筆記 YAML 中加入 `cssclasses: cornell` 即可使用。"
         type: heading
         level: 3
         collapsed: false
     -
         id: documentation-cssclass-cornell
         title: Documentation for Cornell Notes CSSClass
+        title.zh: "康奈尔笔记 CSSClass 文档"
+        title.zh-TW: "康奈爾筆記 CSSClass 文件"
         type: info-text
         description: "[Example](https://willemstad.cc/Features/Global+CSSClass/Cornell+Notes+Example) [Docs](https://willemstad.cc/Features/Global+CSSClass/Cornell+Notes)"
+        description.zh: "[示例](https://willemstad.cc/Features/Global+CSSClass/Cornell+Notes+Example) [文档](https://willemstad.cc/Features/Global+CSSClass/Cornell+Notes)"
+        description.zh-TW: "[示例](https://willemstad.cc/Features/Global+CSSClass/Cornell+Notes+Example) [文件](https://willemstad.cc/Features/Global+CSSClass/Cornell+Notes)"
         markdown: true
     -
         id: cssc-cornell-aside-min
         title: "Minimum Aside Width"
+        title.zh: "旁注最小宽度"
+        title.zh-TW: "旁註最小寬度"
         type: variable-number-slider
         description: "Sets the minimum pixel width for the aside panel. The aside will not shrink below this size."
+        description.zh: "设置旁注面板的最小像素宽度，面板不会缩小到此值以下。"
+        description.zh-TW: "設定旁註面板的最小畫素寬度，面板不會縮小到此值以下。"
         default: 125
         min: 50
         max: 300
@@ -50112,8 +51816,12 @@ settings:
     -
         id: cssc-cornell-aside-max
         title: "Preferred Aside Width"
+        title.zh: "旁注首选宽度"
+        title.zh-TW: "旁註首選寬度"
         type: variable-number-slider
         description: "Use this setting to change the preferred percentage width of the left aside panel."
+        description.zh: "设置左侧旁注面板的首选宽度百分比。"
+        description.zh-TW: "設定左側旁註面板的首選寬度百分比。"
         default: 30
         min: 10
         max: 50
@@ -50122,12 +51830,20 @@ settings:
     -
         id: cssc-cornell-gap
         title: "Gap Between Left and Right Content"
+        title.zh: "左右内容间距"
+        title.zh-TW: "左右內容間距"
         type: variable-text
         description: "Use this setting to change the gap between the left and right content of the Cornell Notes CSSClass."
+        description.zh: "设置康奈尔笔记 CSSClass 左右内容之间的间距。"
+        description.zh-TW: "設定康奈爾筆記 CSSClass 左右內容之間的間距。"
         default: "var(--p-spacing)"
     -
         id: cssc-cornell-text-align
         title: "Text Alignment"
+        title.zh: "文本对齐方式"
+        title.zh-TW: "文本對齊方式"
+        description.zh: "选项含义：Justify：两端对齐；Left：左；Right：右；Centre：居中。"
+        description.zh-TW: "選項含義：Justify：兩端對齊；Left：左；Right：右；Centre：居中。"
         type: variable-select
         default: justify
         options:
@@ -50146,6 +51862,10 @@ settings:
     -
         id: cssc-cornell-text-align-last
         title: "Text Alignment (Last Line)"
+        title.zh: "末行文本对齐方式"
+        title.zh-TW: "末行文本對齊方式"
+        description.zh: "选项含义：Justify：两端对齐；Left：左；Right：右；Centre：居中。"
+        description.zh-TW: "選項含義：Justify：兩端對齊；Left：左；Right：右；Centre：居中。"
         type: variable-select
         default: right
         options:


### PR DESCRIPTION
Closes #17.

## Problem and Reproduction

With Willemstad at `a8bd0eb`, the theme's Style Settings titles and descriptions remain English when Obsidian is set to either Simplified or Traditional Chinese. The plugin can translate its own controls, but Willemstad provides no translated metadata for it to select.

Reproduced in an isolated Windows vault with Obsidian 1.13.7 and Style Settings 1.0.9:

1. Install Willemstad and enable the Style Settings community plugin.
2. In Obsidian's general settings, select Simplified Chinese (`zh`) and reload the application.
3. Open Style Settings and expand **Willemstad > Root Options and Settings**.
4. Observe English theme text such as **No Animations**, **No Blur Backdrop Filter**, and their descriptions, even though the plugin's default-value caption is Chinese.
5. Repeat with Traditional Chinese (`zh-TW`); the theme text still falls back to English.

## Change and Rationale

Add the plugin's supported `title.zh`, `title.zh-TW`, `description.zh`, and `description.zh-TW` fields alongside the existing English metadata. Coverage includes both the current `theme.css` and compatibility `obsidian.css` distribution:

| Distribution | Sections | Existing titles translated per locale | Descriptions supplied per locale | Dropdown explanations per locale |
| --- | ---: | ---: | ---: | ---: |
| `theme.css` | 12 | 480 | 380 | 41 |
| `obsidian.css` | 6 | 295 | 177 | 10 |

The translations cover typography, colours, the application UI, editor settings, callouts, plugins, credits, CSSClasses, and compatibility settings. Technical identifiers, copyable syntax, contributor names, plugin names, and documentation URLs remain usable. Traditional Chinese uses regional terms such as `設定`, `字型`, `字級`, `即時預覽`, and `原始碼模式`.

The [Style Settings localization contract](https://github.com/community-archive/obsidian-style-settings#localization-support) supports setting titles and descriptions. Its renderer does not localize section names or dropdown labels, so this change keeps those English labels and adds Chinese explanations for common dropdown choices in localized descriptions. Plugin-owned captions and CSS-generated notices retain their existing language. No unsupported `name.zh` or `label.zh` fields are added.

All original English fields, setting IDs, types, defaults, dropdown values, CSS selectors, and declarations are unchanged. Existing saved settings and English fallback behavior are preserved. Historical `old/` and `V1.9/` files are untouched.

## Verification

- Parsed all 18 settings blocks with `js-yaml 4.1.0`; verified complete `zh` and `zh-TW` coverage for every existing nonempty title and description.
- Removed only the added locale fields and compared the complete parsed structure against `a8bd0eb`: identical, including all IDs, defaults, option labels, and values.
- Removed only the added locale lines and compared file content against the baseline: identical, including the CSS outside metadata.
- Loaded both distributions in the actual Obsidian application with Style Settings 1.0.9 in `en`, `zh`, and `zh-TW`. All 12 current sections and all 6 compatibility sections loaded without Style Settings errors.
- Verified **No Animations / 禁用动画 / 停用動畫** in the rendered interface, toggled the setting, then reloaded the plugin after changing language. The same saved setting remained enabled and its original CSS class remained applied in both distributions.
- Visually inspected full-window screenshots at 1440 x 1000 for Simplified Chinese, Traditional Chinese, English fallback, and compatibility metadata.
- `git diff --check`: passed.

The legacy multiline columns-syntax description is preserved exactly. It already loads in Obsidian and `js-yaml 4.1.0`; stricter YAML parsers report its existing indentation issue. This PR does not alter that syntax or attribute it to an unrelated issue.

Only Windows was tested. No macOS, iOS, or Android execution is claimed.

## Combining the Related Fixes

An isolated integration of #82 through #89 passed 25 targeted real-application checks, including the new block-width controls with active-line highlighting and English/Simplified/Traditional settings. The only text conflict is `info-editor-block-widths` when combined with #86: retain #86's expanded English description and its matching new Chinese descriptions. No runtime CSS conflict was found. [Integration receipt](https://github.com/oldwinter/willemstad-x/blob/codex-willemstad-issue-evidence/verification/integration-results.json).

## Screenshots

[Full metadata validation](https://github.com/oldwinter/willemstad-x/blob/codex-willemstad-issue-evidence/verification/localization-validation.json).

Before, Simplified Chinese selected:

![Before: English theme settings under the Chinese locale](https://raw.githubusercontent.com/oldwinter/willemstad-x/codex-willemstad-issue-evidence/verification/localization-before-zh.png)

After, Simplified Chinese:

![After: Simplified Chinese setting titles and descriptions](https://raw.githubusercontent.com/oldwinter/willemstad-x/codex-willemstad-issue-evidence/verification/localization-after-zh.png)

After, Traditional Chinese:

![After: Traditional Chinese setting titles and descriptions](https://raw.githubusercontent.com/oldwinter/willemstad-x/codex-willemstad-issue-evidence/verification/localization-after-zh-TW.png)

Compatibility distribution, Traditional Chinese:

![Compatibility distribution with Traditional Chinese metadata](https://raw.githubusercontent.com/oldwinter/willemstad-x/codex-willemstad-issue-evidence/verification/localization-compat-zh-TW.png)

English fallback remains unchanged:

![English fallback](https://raw.githubusercontent.com/oldwinter/willemstad-x/codex-willemstad-issue-evidence/verification/localization-after-en.png)
